### PR TITLE
fix(sandbox): 未使用の checkDist 変数を削除（ビルドエラー修正）

### DIFF
--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -532,7 +532,6 @@ export const SandboxGame = ({
 
             if (myPlayerId !== 'both' && destPid !== myPlayerId) { clearDropHighlight(); setDragState(null); return; }
 
-            const checkDist = (tx: number, ty: number) => Math.sqrt(Math.pow(tx - endPos.x, 2) + Math.pow(ty - endPos.y, 2));
             const THRESHOLD = coords.CH;
 
             if (card.card_id === "DON" || card.type === "DON") {


### PR DESCRIPTION
## Summary

- `onPointerUp` 内で `checkZone` を `getDropZone` に置き換えた際、`checkDist` が未使用になったため削除
- `tsc -b` でエラーコード 2 が発生していたビルド失敗を修正

https://claude.ai/code/session_01Hw6GVsC5o9YnpbX1TbMAF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw6GVsC5o9YnpbX1TbMAF3)_