### PR TITLE
fix: ドロップ先ハイライト — フィールド・DONキャラアタッチを修正

### DIFF
--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -532,7 +532,6 @@ export const SandboxGame = ({
 
             if (myPlayerId !== 'both' && destPid !== myPlayerId) { clearDropHighlight(); setDragState(null); return; }
 
-            const checkDist = (tx: number, ty: number) => Math.sqrt(Math.pow(tx - endPos.x, 2) + Math.pow(ty - endPos.y, 2));
             const THRESHOLD = coords.CH;
 
             if (card.card_id === "DON" || card.type === "DON") {

--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -60,6 +60,7 @@ const getDropZone = (
   const THRESHOLD = coords.CH;
   const getX = (val: number) => isTopArea ? W - val : val;
   const yBase = isTopArea ? 0 : midY;
+  const r1Y = isTopArea ? coords.midY - coords.getY(1) - coords.CH / 2 : yBase + coords.getY(1) + coords.CH / 2;
   const r2Y = isTopArea ? coords.midY - coords.getY(2) - coords.CH / 2 : yBase + coords.getY(2) + coords.CH / 2;
   const r3Y = isTopArea ? coords.midY - coords.getY(3) - coords.CH / 2 : yBase + coords.getY(3) + coords.CH / 2;
   const r4Y = isTopArea ? coords.midY - coords.getY(4) - coords.CH / 2 : yBase + coords.getY(4) + coords.CH / 2;
@@ -73,6 +74,7 @@ const getDropZone = (
   if (checkDist(getX(coords.getDonDeckX(W)), r3Y) < THRESHOLD) return 'don_deck';
   if (checkDist(getX(coords.getDonActiveX(W)), r3Y) < THRESHOLD) return 'don_active';
   if (checkDist(getX(coords.getDonRestX(W)), r3Y) < THRESHOLD) return 'don_rested';
+  if (Math.abs(r1Y - pos.y) < coords.CH) return 'field';
   return null;
 };
 

--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -477,14 +477,37 @@ export const SandboxGame = ({
           }
           const g = dropHighlightRef.current;
           g.clear();
+
+          let hlRect: { x: number; y: number; w: number; h: number } | null = null;
+
           if (zone) {
-            const rect = getZoneRect(zone, isTopArea, W, H, coords);
-            if (rect) {
-              g.lineStyle(3, 0xffd700, 1);
-              g.beginFill(0xffd700, 0.2);
-              g.drawRoundedRect(rect.x - rect.w / 2, rect.y - rect.h / 2, rect.w, rect.h, 8);
-              g.endFill();
+            hlRect = getZoneRect(zone, isTopArea, W, H, coords);
+          } else if (dragState.card.card_id === "DON" || dragState.card.type === "DON") {
+            // DONカードをフィールドキャラへアタッチする場合の個別ポジション判定
+            const midY = H / 2;
+            const THRESHOLD = coords.CH;
+            const destPid = isTopArea ? (isRotated ? 'p1' : 'p2') : (isRotated ? 'p2' : 'p1');
+            const targetPlayer = destPid === 'p1' ? gameState?.players.p1 : gameState?.players.p2;
+            if (targetPlayer) {
+              const getX = (val: number) => isTopArea ? W - val : val;
+              const yBase = isTopArea ? 0 : midY;
+              const fieldY = isTopArea ? (midY - coords.getY(1) - coords.CH / 2) : (yBase + coords.getY(1) + coords.CH / 2);
+              const fieldCards = targetPlayer.zones.field;
+              for (let i = 0; i < fieldCards.length; i++) {
+                const cx = getX(coords.getFieldX(i, W, coords.CW, fieldCards.length));
+                if (Math.abs(e.clientX - cx) < THRESHOLD && Math.abs(e.clientY - fieldY) < THRESHOLD) {
+                  hlRect = { x: cx, y: fieldY, w: coords.CW, h: coords.CH };
+                  break;
+                }
+              }
             }
+          }
+
+          if (hlRect) {
+            g.lineStyle(3, 0xffd700, 1);
+            g.beginFill(0xffd700, 0.2);
+            g.drawRoundedRect(hlRect.x - hlRect.w / 2, hlRect.y - hlRect.h / 2, hlRect.w, hlRect.h, 8);
+            g.endFill();
           }
         }
     };


### PR DESCRIPTION
## 修正内容

### 問題
- カードをフィールドへドラッグ中にハイライトが表示されない
- DONカードをフィールドキャラへドラッグ中にハイライトが表示されない

### 原因
1. `getDropZone()` に Row 1（フィールド行）の Y バンド判定が欠けていた
2. `getDropZone()` はゲームステートを持たないため、個別カード位置（`getFieldX(i, ...)`）を判定できなかった

### 対応
1. `getDropZone()` に `r1Y` 基準の Y 距離チェックを追加し `'field'` を返すよう修正
2. `onPointerMove` の DON カードドラッグ時、`getDropZone()` が null を返した場合に `gameState` のフィールドカードを走査して個別の矩形ハイライトを描画

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw6GVsC5o9YnpbX1TbMAF3)_