### PR TITLE
feat: デッキ選択画面のSETボタンを廃止し操作を簡略化

### DIFF
--- a/src/game/localActionHandler.ts
+++ b/src/game/localActionHandler.ts
@@ -25,14 +25,15 @@ export const handleLocalAction = (state: GameState, actionType: string, params: 
     case 'SET_DECK': {
       const newState = JSON.parse(JSON.stringify(state));
       const pid = params.player_id as 'p1' | 'p2';
-      
+      if (!newState.ready_states) newState.ready_states = { p1: false, p2: false };
+
       newState.players[pid].name = params.deck_id;
 
       if (params.deckData && params.deckData.leader) {
-        const leaderData = Array.isArray(params.deckData.leader) 
-          ? params.deckData.leader[0] 
+        const leaderData = Array.isArray(params.deckData.leader)
+          ? params.deckData.leader[0]
           : params.deckData.leader;
-          
+
         if (leaderData) {
           // ▼ 修正: uuidを上書きする前に、元のID（カード品番）を card_id として確保する
           const originalId = leaderData.card_id || leaderData.uuid || leaderData.id;
@@ -43,9 +44,11 @@ export const handleLocalAction = (state: GameState, actionType: string, params: 
             uuid: `leader-${pid}-${Date.now()}`, // ゲーム内での一意なID
             owner_id: params.deck_id
           };
+          // デッキ選択＝準備完了とみなす（SETボタンを廃止し操作を簡略化）
+          newState.ready_states[pid] = true;
         }
       }
-      
+
       return newState;
     }
 

--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -818,41 +818,27 @@ export const SandboxGame = ({
                 </div>
                 
                 {(pid === myPlayerId || myPlayerId === 'both') ? (
-                  <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
-                    <div 
-                      onClick={() => setSelectingDeckFor(pid)}
-                      style={{ 
-                        flex: 1, height: '60px', 
-                        background: '#2a1a1a', border: '1px solid #5d4037', borderRadius: '4px',
-                        display: 'flex', alignItems: 'center', justifyContent: 'center',
-                        cursor: 'pointer', overflow: 'hidden', position: 'relative'
-                      }}
-                    >
-                      {hasDeck ? (
-                        <>
-                          <img 
-                            src={getCardImageUrl(leaderCard?.card_id)} 
-                            alt="leader"
-                            style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', objectFit: 'cover', opacity: 0.6 }} 
-                          />
-                          <span style={{ zIndex: 1, fontWeight: 'bold', textShadow: '0 2px 4px black' }}>{leaderCard?.name || 'Deck Selected'}</span>
-                        </>
-                      ) : (
-                        <span style={{ color: '#7f8c8d', fontSize: '14px' }}>＋ デッキを選択</span>
-                      )}
-                    </div>
-
-                    <button 
-                      onClick={() => handleAction('READY', { player_id: pid })} 
-                      disabled={!hasDeck}
-                      style={{ 
-                        width: '80px', height: '60px',
-                        background: gameState?.ready_states?.[pid] ? '#2ecc71' : (hasDeck ? '#e67e22' : '#555'), 
-                        color: 'white', border: 'none', borderRadius: '4px', fontWeight: 'bold', cursor: hasDeck ? 'pointer' : 'not-allowed'
-                      }}
-                    >
-                      {gameState?.ready_states?.[pid] ? 'OK' : 'SET'}
-                    </button>
+                  <div
+                    onClick={() => setSelectingDeckFor(pid)}
+                    style={{
+                      height: '60px',
+                      background: '#2a1a1a', border: '1px solid #5d4037', borderRadius: '4px',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      cursor: 'pointer', overflow: 'hidden', position: 'relative'
+                    }}
+                  >
+                    {hasDeck ? (
+                      <>
+                        <img
+                          src={getCardImageUrl(leaderCard?.card_id)}
+                          alt="leader"
+                          style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', objectFit: 'cover', opacity: 0.6 }}
+                        />
+                        <span style={{ zIndex: 1, fontWeight: 'bold', textShadow: '0 2px 4px black' }}>{leaderCard?.name || 'Deck Selected'}</span>
+                      </>
+                    ) : (
+                      <span style={{ color: '#7f8c8d', fontSize: '14px' }}>＋ デッキを選択</span>
+                    )}
                   </div>
                 ) : (
                   <div style={{ height: '60px', background: 'rgba(0,0,0,0.2)', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#7f8c8d', fontSize: '14px', border: '1px dashed #555' }}>

--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -109,6 +109,43 @@ const getZoneRect = (
   }
 };
 
+type DonTarget = { kind: 'leader' | 'field'; index: number; x: number; y: number };
+
+// DONカードのアタッチ先（リーダー or フィールドキャラ）を「最も近いカード」で解決する。
+// ハイライト(onPointerMove)とドロップ実行(onPointerUp)で共通利用し、判定の不一致を防ぐ。
+const getDonAttachTarget = (
+  pos: { x: number; y: number },
+  isTopArea: boolean,
+  W: number,
+  H: number,
+  coords: ReturnType<typeof calculateCoordinates>,
+  hasLeader: boolean,
+  fieldCount: number
+): DonTarget | null => {
+  const midY = H / 2;
+  const getX = (val: number) => isTopArea ? W - val : val;
+  const yBase = isTopArea ? 0 : midY;
+  const leaderY = isTopArea ? (coords.midY - coords.getY(2) - coords.CH / 2) : (yBase + coords.getY(2) + coords.CH / 2);
+  const fieldY = isTopArea ? (coords.midY - coords.getY(1) - coords.CH / 2) : (yBase + coords.getY(1) + coords.CH / 2);
+
+  let best: DonTarget | null = null;
+  let bestDist = Infinity;
+  const consider = (kind: 'leader' | 'field', index: number, cx: number, cy: number) => {
+    const dx = pos.x - cx, dy = pos.y - cy;
+    // 縦横ともカード幅/高さの半分以内をターゲット領域とし、その中で最も近い中心を採用
+    if (Math.abs(dx) < coords.CW / 2 && Math.abs(dy) < coords.CH / 2) {
+      const d = dx * dx + dy * dy;
+      if (d < bestDist) { bestDist = d; best = { kind, index, x: cx, y: cy }; }
+    }
+  };
+
+  if (hasLeader) consider('leader', -1, getX(coords.getLeaderX(W)), leaderY);
+  for (let i = 0; i < fieldCount; i++) {
+    consider('field', i, getX(coords.getFieldX(i, W, coords.CW, fieldCount)), fieldY);
+  }
+  return best;
+};
+
 interface SandboxGameProps { 
   gameId?: string; 
   myPlayerId?: string; 
@@ -482,28 +519,20 @@ export const SandboxGame = ({
           const isDon = dragState.card.card_id === "DON" || dragState.card.type === "DON";
 
           if (isDon) {
-            // DONカード: フィールドキャラへのアタッチを個別カード単位で判定（バンド表示しない）
-            const midY = H / 2;
-            const THRESHOLD = coords.CH;
+            // DONカード: リーダー/フィールドキャラのうち最も近い1枚にハイライト（バンド表示しない）
             const destPid = isTopArea ? (isRotated ? 'p1' : 'p2') : (isRotated ? 'p2' : 'p1');
             const targetPlayer = destPid === 'p1' ? gameState?.players.p1 : gameState?.players.p2;
             if (targetPlayer) {
-              const getX = (val: number) => isTopArea ? W - val : val;
-              const yBase = isTopArea ? 0 : midY;
-              const fieldY = isTopArea ? (midY - coords.getY(1) - coords.CH / 2) : (yBase + coords.getY(1) + coords.CH / 2);
-              const fieldCards = targetPlayer.zones.field;
-              for (let i = 0; i < fieldCards.length; i++) {
-                const cx = getX(coords.getFieldX(i, W, coords.CW, fieldCards.length));
-                if (Math.abs(e.clientX - cx) < THRESHOLD && Math.abs(e.clientY - fieldY) < THRESHOLD) {
-                  hlRect = { x: cx, y: fieldY, w: coords.CW, h: coords.CH };
-                  break;
-                }
-              }
+              const target = getDonAttachTarget(
+                { x: e.clientX, y: e.clientY }, isTopArea, W, H, coords,
+                !!targetPlayer.leader, targetPlayer.zones.field.length
+              );
+              if (target) hlRect = { x: target.x, y: target.y, w: coords.CW, h: coords.CH };
             }
-            // フィールドキャラ以外はゾーン検出（'field'バンドはDONの有効ドロップ先でないためスキップ）
+            // アタッチ対象が無い場合はDONゾーンのみ検出（'field'バンドはDONの有効ドロップ先でないためスキップ）
             if (!hlRect) {
               const zone = getDropZone({ x: e.clientX, y: e.clientY }, isTopArea, W, H, coords);
-              if (zone && zone !== 'field') hlRect = getZoneRect(zone, isTopArea, W, H, coords);
+              if (zone && zone !== 'field' && zone !== 'leader') hlRect = getZoneRect(zone, isTopArea, W, H, coords);
             }
           } else {
             const zone = getDropZone({ x: e.clientX, y: e.clientY }, isTopArea, W, H, coords);
@@ -562,19 +591,15 @@ export const SandboxGame = ({
 
             if (myPlayerId !== 'both' && destPid !== myPlayerId) { clearDropHighlight(); setDragState(null); return; }
 
-            const THRESHOLD = coords.CH;
-
             if (card.card_id === "DON" || card.type === "DON") {
                 const targetPlayer = destPid === 'p1' ? gameState?.players.p1 : gameState?.players.p2;
                 if (targetPlayer) {
-                    const getX = (val: number) => isTopArea ? W - val : val;
-                    const yBase = isTopArea ? 0 : midY; const leaderY = isTopArea ? (midY - coords.getY(2) - coords.CH/2) : (yBase + coords.getY(2) + coords.CH/2);
-                    if (targetPlayer.leader && Math.abs(endPos.x - getX(coords.getLeaderX(W))) < THRESHOLD && Math.abs(endPos.y - leaderY) < THRESHOLD) { handleAction('ATTACH_DON', { card_uuid: card.uuid, target_uuid: targetPlayer.leader.uuid }); clearDropHighlight(); setDragState(null); return; }
-                    const fieldY = isTopArea ? (midY - coords.getY(1) - coords.CH/2) : (yBase + coords.getY(1) + coords.CH/2);
-                    const fieldCards = targetPlayer.zones.field;
-                    for (let i = 0; i < fieldCards.length; i++) {
-                        const cx = getX(coords.getFieldX(i, W, coords.CW, fieldCards.length));
-                        if (Math.abs(endPos.x - cx) < THRESHOLD && Math.abs(endPos.y - fieldY) < THRESHOLD) { handleAction('ATTACH_DON', { card_uuid: card.uuid, target_uuid: fieldCards[i].uuid }); clearDropHighlight(); setDragState(null); return; }
+                    // ハイライトと同じリゾルバで「最も近いカード」を解決
+                    const target = getDonAttachTarget(endPos, isTopArea, W, H, coords, !!targetPlayer.leader, targetPlayer.zones.field.length);
+                    if (target) {
+                        const targetUuid = target.kind === 'leader' ? targetPlayer.leader!.uuid : targetPlayer.zones.field[target.index].uuid;
+                        handleAction('ATTACH_DON', { card_uuid: card.uuid, target_uuid: targetUuid });
+                        clearDropHighlight(); setDragState(null); return;
                     }
                 }
                 const dZone = getDropZone(endPos, isTopArea, W, H, coords); if (dZone && ['don_active', 'don_rested', 'don_deck'].includes(dZone)) handleAction('MOVE_CARD', { card_uuid: card.uuid, dest_player_id: destPid, dest_zone: dZone });


### PR DESCRIPTION
## 変更内容
ゲーム開始時のデッキ選択画面から **SET/OK ボタンを廃止**し、操作を簡略化しました。

### Before
デッキ選択 → **SET ボタン押下で READY** → GAME START（2ステップ）

### After
デッキ選択 → **自動で READY** → GAME START（1ステップ）

VS CPU モード（RealGame）は元々 SET ボタンが無く「選択 → GAME START」だったため、サンドボックス（1人回し）モードもこれに統一しました。

### 実装
- `localActionHandler.ts`: `SET_DECK` で有効なリーダーが設定されたら `ready_states[pid] = true` を自動セット
- `SandboxGame.tsx`: セットアップ画面の SET/OK ボタンと flex ラッパーを削除し、デッキ選択ボックスを全幅化。READY 状態は右上のラベル（READY / NOT READY）で引き続き表示

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw6GVsC5o9YnpbX1TbMAF3)_