### PR TITLE
fix: P2がルーム入室後にデッキ選択できるよう修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,7 +116,7 @@ export default function App() {
         {mode === 'lobby' && (
           <RoomLobby
             onBack={() => setMode('start')}
-            onJoin={(gameId) => handleStart(selectedDecks.p1, selectedDecks.p2, 'sandbox', { role: 'p2', gameId })}
+            onJoin={(gameId) => handleStart('', '', 'sandbox', { role: 'p2', gameId })}
             onCreate={(roomName) => handleStart('', '', 'sandbox', { role: 'p1', room_name: roomName })}
           />
         )}


### PR DESCRIPTION
## Summary
- `onJoin` の引数を `selectedDecks.p1/p2`（デフォルト値 `imu.json` 等）から `'', ''` に変更
- P1・P2 ともにルーム入室後のセットアップ画面でデッキ選択できるようになる
- P2 がローディングで止まるバグも解消（`shouldShowSetupScreen=true` となり PIXI ボードに進まなくなる）

https://claude.ai/code/session_01Hw6GVsC5o9YnpbX1TbMAF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw6GVsC5o9YnpbX1TbMAF3)_