### PR TITLE
feat: 入室時ロール自動決定とキック機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,13 +101,14 @@ export default function App() {
           <RealGame p1Deck={selectedDecks.p1} p2Deck={selectedDecks.p2} onBack={() => { if (confirm("終了しますか？")) setMode('start'); }} />
         )}
         {mode === 'sandbox' && (
-          <SandboxGame 
-            myPlayerId={sandboxOptions.role === 'both' ? 'both' : sandboxOptions.role} 
-            gameId={sandboxOptions.gameId} 
-            roomName={sandboxOptions.room_name} 
+          <SandboxGame
+            myPlayerId={sandboxOptions.role === 'both' ? 'both' : sandboxOptions.role}
+            gameId={sandboxOptions.gameId}
+            roomName={sandboxOptions.room_name}
             initialP1DeckId={selectedDecks.p1}
             initialP2DeckId={selectedDecks.p2}
-            onBack={() => { if (confirm("終了しますか？")) setMode('start'); }} 
+            onBack={() => { if (confirm("終了しますか？")) setMode('start'); }}
+            onForceBack={() => setMode('lobby')}
           />
         )}
         {(mode === 'deck' || mode === 'cardList') && (
@@ -116,7 +117,7 @@ export default function App() {
         {mode === 'lobby' && (
           <RoomLobby
             onBack={() => setMode('start')}
-            onJoin={(gameId) => handleStart('', '', 'sandbox', { role: 'p2', gameId })}
+            onJoin={(gameId, role) => handleStart('', '', 'sandbox', { role, gameId })}
             onCreate={(gameId) => handleStart('', '', 'sandbox', { role: 'p1', gameId })}
           />
         )}

--- a/src/screens/RoomLobby.tsx
+++ b/src/screens/RoomLobby.tsx
@@ -10,11 +10,13 @@ interface RoomInfo {
   p2_name: string;
   turn: number;
   created_at: string;
+  active_connections: number;
+  status: string;
 }
 
 interface RoomLobbyProps {
   onBack: () => void;
-  onJoin: (gameId: string) => void;
+  onJoin: (gameId: string, role: 'p1' | 'p2') => void;
   onCreate: (gameId: string) => void;
 }
 
@@ -113,20 +115,27 @@ export const RoomLobby: React.FC<RoomLobbyProps> = ({ onBack, onJoin, onCreate }
           </div>
         ) : (
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: '15px' }}>
-            {rooms.map(room => (
-              <div 
-                key={room.game_id} 
-                onClick={() => onJoin(room.game_id)}
-                style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid #555', borderRadius: '12px', padding: '20px', cursor: 'pointer', transition: 'transform 0.2s', position: 'relative' }}
-                onMouseOver={(e) => e.currentTarget.style.background = 'rgba(255,255,255,0.1)'}
+            {rooms.filter(r => r.status === 'WAITING').map(room => {
+              const isFull = room.active_connections >= 2;
+              const role: 'p1' | 'p2' = room.active_connections === 0 ? 'p1' : 'p2';
+              return (
+              <div
+                key={room.game_id}
+                onClick={() => { if (!isFull) onJoin(room.game_id, role); }}
+                style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid #555', borderRadius: '12px', padding: '20px', cursor: isFull ? 'not-allowed' : 'pointer', transition: 'transform 0.2s', position: 'relative', opacity: isFull ? 0.6 : 1 }}
+                onMouseOver={(e) => { if (!isFull) e.currentTarget.style.background = 'rgba(255,255,255,0.1)'; }}
                 onMouseOut={(e) => e.currentTarget.style.background = 'rgba(255,255,255,0.05)'}
               >
                 <div style={{ color: '#d4af37', fontWeight: 'bold', fontSize: '18px', marginBottom: '10px' }}>{room.room_name}</div>
                 <div style={{ fontSize: '14px', color: '#ccc' }}>Host: {room.p1_name}</div>
                 <div style={{ fontSize: '12px', color: '#888', marginTop: '5px' }}>Turn: {room.turn} | Created: {formatTime(room.created_at)}</div>
-                <div style={{ position: 'absolute', bottom: '20px', right: '20px', padding: '4px 12px', background: '#3498db', borderRadius: '20px', fontSize: '12px', fontWeight: 'bold' }}>JOIN</div>
+                {isFull ? (
+                  <div style={{ position: 'absolute', bottom: '20px', right: '20px', padding: '4px 12px', background: '#7f8c8d', borderRadius: '20px', fontSize: '12px', fontWeight: 'bold' }}>FULL</div>
+                ) : (
+                  <div style={{ position: 'absolute', bottom: '20px', right: '20px', padding: '4px 12px', background: '#3498db', borderRadius: '20px', fontSize: '12px', fontWeight: 'bold' }}>JOIN</div>
+                )}
               </div>
-            ))}
+            );})}
           </div>
         )}
       </div>

--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -149,22 +149,24 @@ const getDonAttachTarget = (
   return best;
 };
 
-interface SandboxGameProps { 
-  gameId?: string; 
-  myPlayerId?: string; 
-  roomName?: string; 
+interface SandboxGameProps {
+  gameId?: string;
+  myPlayerId?: string;
+  roomName?: string;
   onBack: () => void;
+  onForceBack?: () => void;
   initialP1DeckId?: string;
   initialP2DeckId?: string;
 }
 
-export const SandboxGame = ({ 
-  gameId: initialGameId, 
-  myPlayerId = 'both', 
-  roomName, 
+export const SandboxGame = ({
+  gameId: initialGameId,
+  myPlayerId = 'both',
+  roomName,
   onBack,
-  initialP1DeckId, 
-  initialP2DeckId 
+  onForceBack,
+  initialP1DeckId,
+  initialP2DeckId
 }: SandboxGameProps) => {
   const pixiContainerRef = useRef<HTMLDivElement>(null);
   const appRef = useRef<PIXI.Application | null>(null);
@@ -372,7 +374,13 @@ export const SandboxGame = ({
       ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          if (data.type === 'STATE_UPDATE') setGameState(data.state);
+          if (data.type === 'STATE_UPDATE') {
+            setGameState(data.state);
+            if (data.kicked_player && data.kicked_player === myPlayerId) {
+              if (onForceBack) onForceBack();
+              else onBack();
+            }
+          }
         } catch(e) { logger.error('ws.parse_error', String(e)); }
       };
       ws.onerror = () => { logger.error('ws.error', 'WebSocket error'); };
@@ -920,6 +928,23 @@ export const SandboxGame = ({
                   <div style={{ height: '60px', background: 'rgba(0,0,0,0.2)', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#7f8c8d', fontSize: '14px', border: '1px dashed #555' }}>
                     {hasDeck ? 'Deck Selected' : 'Waiting for selection...'}
                   </div>
+                )}
+                {myPlayerId === 'p1' && pid === 'p2' && (
+                  <button
+                    onClick={() => handleAction('KICK_PLAYER', { target_player_id: 'p2' })}
+                    style={{
+                      alignSelf: 'flex-end',
+                      padding: '4px 10px',
+                      background: 'transparent',
+                      border: '1px solid #e74c3c',
+                      color: '#e74c3c',
+                      borderRadius: '4px',
+                      fontSize: '11px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    キック
+                  </button>
                 )}
               </div>
             );


### PR DESCRIPTION
## Summary
- ロビーの `active_connections` 数に応じて P1/P2 を自動割り当て（0接続→P1, 1接続→P2, 2接続→FULL）
- P1 はセットアップ画面から P2 をキック可能（`KICK_PLAYER` アクション）
- キックされた P2 は確認ダイアログなしでロビーへ自動遷移

https://claude.ai/code/session_01Hw6GVsC5o9YnpbX1TbMAF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw6GVsC5o9YnpbX1TbMAF3)_