### PR TITLE
フロント型/lint クリーンアップ: lint 137→0（any全廃・state喪失バグ修正・ビルド緑）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,10 +44,13 @@ class ErrorBoundary extends Component<Props, State> {
   }
 }
 
+type AppMode = 'start' | 'game' | 'deck' | 'sandbox' | 'cardList' | 'lobby';
+type SandboxOptions = { role: 'both' | 'p1' | 'p2'; gameId?: string; room_name?: string };
+
 export default function App() {
   // 対策①：初期値をsessionStorageから復元するように変更
-  const [mode, setMode] = useState<'start' | 'game' | 'deck' | 'sandbox' | 'cardList' | 'lobby'>(() => {
-    return (sessionStorage.getItem('opcg_app_mode') as any) || 'start';
+  const [mode, setMode] = useState<AppMode>(() => {
+    return (sessionStorage.getItem('opcg_app_mode') as AppMode | null) || 'start';
   });
 
   const [selectedDecks, setSelectedDecks] = useState<{ p1: string; p2: string }>(() => {
@@ -55,7 +58,7 @@ export default function App() {
     return saved ? JSON.parse(saved) : { p1: 'imu.json', p2: 'nami.json' };
   });
 
-  const [sandboxOptions, setSandboxOptions] = useState<{ role: 'both' | 'p1' | 'p2', gameId?: string, room_name?: string }>(() => {
+  const [sandboxOptions, setSandboxOptions] = useState<SandboxOptions>(() => {
     const saved = sessionStorage.getItem('opcg_sandbox_options');
     return saved ? JSON.parse(saved) : { role: 'both' };
   });
@@ -73,7 +76,7 @@ export default function App() {
     sessionStorage.setItem('opcg_sandbox_options', JSON.stringify(sandboxOptions));
   }, [sandboxOptions]);
 
-  const handleStart = (p1: string, p2: string, gameMode: 'normal' | 'sandbox' = 'normal', sbOptions?: any) => {
+  const handleStart = (p1: string, p2: string, gameMode: 'normal' | 'sandbox' = 'normal', sbOptions?: SandboxOptions) => {
     
     if (gameMode === 'sandbox') {
         // メニューから新規にサンドボックスを開始する場合は、前回の進行中ゲーム保存を破棄する

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { GameActionRequest, BattleActionRequest, GameActionResult } from './types';
+import type { GameActionRequest, BattleActionRequest, GameActionResult, PendingRequest } from './types';
 import type { GameState } from '../game/types';
 import { API_CONFIG } from './api.config';
 import CONST from '../../shared_constants.json';
@@ -42,7 +42,7 @@ export const apiClient = {
   async createGame(
     p1Deck: string = DEFAULT_GAME_SETTINGS.P1_DECK,
     p2Deck: string = DEFAULT_GAME_SETTINGS.P2_DECK
-  ): Promise<{ game_id: string; state: GameState; pending_request?: any }> {
+  ): Promise<{ game_id: string; state: GameState; pending_request?: PendingRequest }> {
     const res = await fetchWithLog(`${BASE_URL}${ENDPOINTS.CREATE_GAME}`, {
       method: 'POST',
       body: JSON.stringify({
@@ -64,7 +64,7 @@ export const apiClient = {
 
     const oldSid = sessionManager.getSessionId();
     const GAME_ID_KEY = CONST.API_ROOT_KEYS.GAME_ID;
-    const gameId = data[GAME_ID_KEY] || (data[CONST.API_ROOT_KEYS.GAME_STATE] as any)?.[GAME_ID_KEY];
+    const gameId = data[GAME_ID_KEY] || data[CONST.API_ROOT_KEYS.GAME_STATE]?.[GAME_ID_KEY];
     
     if (gameId) {
       sessionManager.setSessionId(gameId);

--- a/src/game/actions.ts
+++ b/src/game/actions.ts
@@ -5,6 +5,9 @@ import type { GameActionRequest, ActionType, BattleActionRequest, PendingRequest
 import type { GameState } from './types';
 import { logger } from '../utils/logger';
 
+// API クライアントが throw するエラー（部分的に game_state/pending_request を含み得る）。
+type ApiActionError = { message?: string; game_state?: GameState; pending_request?: PendingRequest | null };
+
 export const useGameAction = (
   playerId: string,
   setGameState: (state: GameState) => void,
@@ -31,8 +34,8 @@ export const useGameAction = (
       if (pending_request) {
         setPendingRequest(pending_request);
       }
-    } catch (e: any) {
-      setErrorToast(`ゲーム開始エラー: ${e.message}`);
+    } catch (e) {
+      setErrorToast(`ゲーム開始エラー: ${(e as ApiActionError).message}`);
     } finally {
       setIsPending(false);
     }
@@ -70,12 +73,11 @@ export const useGameAction = (
       setGameState(result.game_state);
       setPendingRequest(result.pending_request || null);
       if (result.action_events?.length) addEventLog?.(result.action_events);
-    } catch (e: any) {
-      if (e.game_state || e.pending_request) {
-        setGameState(e.game_state);
-        setPendingRequest(e.pending_request || null);
-      }
-      setErrorToast(`アクション失敗: ${e.message}`);
+    } catch (e) {
+      const err = e as ApiActionError;
+      if (err.game_state) setGameState(err.game_state);
+      if (err.pending_request !== undefined) setPendingRequest(err.pending_request || null);
+      setErrorToast(`アクション失敗: ${err.message}`);
     } finally {
       setIsPending(false);
     }
@@ -109,14 +111,15 @@ export const useGameAction = (
       setGameState(result.game_state);
       setPendingRequest(result.pending_request || null);
       if (result.action_events?.length) addEventLog?.(result.action_events);
-    } catch (e: any) {
-      if (e.game_state) {
-        setGameState(e.game_state);
+    } catch (e) {
+      const err = e as ApiActionError;
+      if (err.game_state) {
+        setGameState(err.game_state);
       }
-      if (e.pending_request !== undefined) {
-        setPendingRequest(e.pending_request || null);
+      if (err.pending_request !== undefined) {
+        setPendingRequest(err.pending_request || null);
       }
-      setErrorToast(`バトルアクション失敗: ${e.message}`);
+      setErrorToast(`バトルアクション失敗: ${err.message}`);
     } finally {
       setIsPending(false);
     }

--- a/src/game/localActionHandler.ts
+++ b/src/game/localActionHandler.ts
@@ -11,9 +11,24 @@ import {
   shuffleDeckLocal,
   resetGameLocal 
 } from './localLogic';
+import type { DeckInput } from './types';
 import { logger } from '../utils/logger';
 
-export const handleLocalAction = (state: GameState, actionType: string, params: any): GameState => {
+// ローカルアクションのペイロード（アクション種別ごとに使うフィールドが異なるため全て optional）。
+interface LocalActionParams {
+  player_id?: string;
+  deck_id?: string;
+  deckData?: DeckInput;
+  card_uuid?: string;
+  target_uuid?: string;
+  dest_player_id?: string;
+  dest_zone?: string;
+  index?: number;
+  p1Deck?: DeckInput;
+  p2Deck?: DeckInput;
+}
+
+export const handleLocalAction = (state: GameState, actionType: string, params: LocalActionParams): GameState => {
   logger.log({
     level: 'info',
     action: `local_action.${actionType}`,
@@ -61,37 +76,37 @@ export const handleLocalAction = (state: GameState, actionType: string, params: 
     }
 
     case 'START':
-      return createInitialGameState(params.p1Deck, params.p2Deck, state.room_name || 'local');
+      return createInitialGameState(params.p1Deck as DeckInput, params.p2Deck as DeckInput, state.room_name || 'local');
 
     case 'MOVE_CARD':
       return moveCardLocal(
         state,
-        params.card_uuid,
+        params.card_uuid as string,
         params.dest_player_id as 'p1' | 'p2',
-        params.dest_zone,
+        params.dest_zone as string,
         params.index
       );
 
     case 'TOGGLE_REST':
-      return toggleRestLocal(state, params.card_uuid);
+      return toggleRestLocal(state, params.card_uuid as string);
 
     case 'ATTACH_DON':
-      return attachDonLocal(state, params.card_uuid, params.target_uuid);
+      return attachDonLocal(state, params.card_uuid as string, params.target_uuid as string);
 
     case 'TURN_END':
       return resolveTurnEndLocal(state);
 
     case 'MULLIGAN':
-      return mulliganLocal(state, params.player_id);
+      return mulliganLocal(state, params.player_id as string);
 
     case 'MULLIGAN_FINISH':
-      return finishMulliganLocal(state, params.player_id);
+      return finishMulliganLocal(state, params.player_id as string);
 
     case 'DRAW':
       return drawCardLocal(state, params.player_id || state.turn_info.active_player_id);
 
     case 'SHUFFLE':
-      return shuffleDeckLocal(state, params.player_id);
+      return shuffleDeckLocal(state, params.player_id as string);
 
     case 'RESET':
       return resetGameLocal(state);

--- a/src/game/localLogic.ts
+++ b/src/game/localLogic.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import type { GameState, CardInstance, PlayerState, LeaderCard, BoardCard } from './types';
+import type { GameState, CardInstance, PlayerState, LeaderCard, BoardCard, DeckInput, DeckCardData, ZoneState } from './types';
 import { logger } from '../utils/logger';
 
 const cloneState = (state: GameState): GameState => JSON.parse(JSON.stringify(state));
@@ -10,11 +10,12 @@ const updatePlayerCounts = (player: PlayerState) => {
   player.active_don = player.don_active.length;
 };
 
-export const createInitialGameState = (p1Deck: any, p2Deck: any, roomName: string): GameState => {
-  const setupPlayer = (deck: any, playerId: string, name: string): PlayerState => {
-    const leaderRaw = (deck?.leader && Array.isArray(deck.leader) ? deck.leader[0] : deck?.leader) || 
-                      (deck?.cards && deck.cards.find((c: any) => (c.type || '').toUpperCase() === 'LEADER')) ||
-                      null;
+export const createInitialGameState = (p1Deck: DeckInput, p2Deck: DeckInput, roomName: string): GameState => {
+  const setupPlayer = (deck: DeckInput, playerId: string, name: string): PlayerState => {
+    const leaderRaw: DeckCardData | null =
+      (deck?.leader && Array.isArray(deck.leader) ? deck.leader[0] : (deck?.leader as DeckCardData | undefined)) ||
+      (deck?.cards && deck.cards.find((c: DeckCardData) => (c.type || '').toUpperCase() === 'LEADER')) ||
+      null;
     
     let leader: LeaderCard | null = null;
     if (leaderRaw) {
@@ -31,12 +32,12 @@ export const createInitialGameState = (p1Deck: any, p2Deck: any, roomName: strin
         is_rest: false,
         attached_don: 0,
         type: "LEADER"
-      };
+      } as LeaderCard;
     }
 
     const mainCards = (deck?.cards || [])
-      .filter((c: any) => (c.type || '').toUpperCase() !== 'LEADER')
-      .map((c: any) => ({
+      .filter((c: DeckCardData) => (c.type || '').toUpperCase() !== 'LEADER')
+      .map((c: DeckCardData) => ({
         ...c,
         // ▼ 修正: メインカードも同様にIDを確保
         card_id: c.card_id || c.uuid || c.number || c.id,
@@ -45,7 +46,7 @@ export const createInitialGameState = (p1Deck: any, p2Deck: any, roomName: strin
         is_rest: false,
         attached_don: 0,
         is_face_up: false
-      }));
+      } as CardInstance));
 
     const shuffled = [...mainCards].sort(() => Math.random() - 0.5);
 
@@ -92,7 +93,7 @@ export const createInitialGameState = (p1Deck: any, p2Deck: any, roomName: strin
     turn_info: { turn_count: 1, active_player_id: 'p1', current_phase: 'MAIN', winner: null }
   };
 
-  (state as any).mulligan_finished = { p1: false, p2: false };
+  state.mulligan_finished = { p1: false, p2: false };
 
   const p1 = state.players.p1;
   const p1DonDeck = p1.zones.don_deck;
@@ -135,9 +136,9 @@ export const moveCardLocal = (state: GameState, cardUuid: string, destPid: 'p1' 
 
     const donKeys = ['don_active', 'don_rested', 'don_attached'] as const;
     for (const key of donKeys) {
-      const idx = (p as any)[key].findIndex((c: any) => c.uuid === cardUuid);
+      const idx = p[key].findIndex((c: CardInstance) => c.uuid === cardUuid);
       if (idx !== -1) { 
-        targetCard = (p as any)[key].splice(idx, 1)[0]; 
+        targetCard = p[key].splice(idx, 1)[0]; 
         sourcePid = pid;
         sourceZone = key;
         break; 
@@ -169,13 +170,13 @@ export const moveCardLocal = (state: GameState, cardUuid: string, destPid: 'p1' 
 
   if (sourceZone === 'field') {
     const srcPlayer = newState.players[sourcePid];
-    const attachedDons = srcPlayer.don_attached.filter((d: any) => d.attached_to === cardUuid);
+    const attachedDons = srcPlayer.don_attached.filter((d) => d.attached_to === cardUuid);
     
     for (const don of attachedDons) {
       const donIdx = srcPlayer.don_attached.indexOf(don);
       if (donIdx !== -1) srcPlayer.don_attached.splice(donIdx, 1);
       don.is_rest = true;
-      (don as any).attached_to = null;
+      don.attached_to = null;
       srcPlayer.don_rested.push(don);
     }
   }
@@ -192,7 +193,7 @@ export const moveCardLocal = (state: GameState, cardUuid: string, destPid: 'p1' 
   const destPlayer = newState.players[destPid];
 
   if (sourceZone === 'hand' && destZone === 'field' && sourcePid === destPid) {
-    const cost = (targetCard as any).cost || 0;
+    const cost = targetCard.cost || 0;
     const activeDons = destPlayer.don_active;
     if (cost > 0 && activeDons.length >= cost) {
       for (let i = 0; i < cost; i++) {
@@ -213,9 +214,9 @@ export const moveCardLocal = (state: GameState, cardUuid: string, destPid: 'p1' 
     }
     destPlayer.stage = targetCard as BoardCard;
   }
-  else if (['don_active', 'don_rested'].includes(destZone)) { (destPlayer as any)[destZone].push(targetCard); }
+  else if (destZone === 'don_active' || destZone === 'don_rested') { destPlayer[destZone].push(targetCard); }
   else {
-    const zone = (destPlayer.zones as any)[destZone];
+    const zone = destPlayer.zones[destZone as keyof ZoneState];
     if (Array.isArray(zone)) {
       if (index === -1) zone.push(targetCard);
       else zone.splice(index, 0, targetCard);
@@ -247,7 +248,7 @@ export const attachDonLocal = (state: GameState, donUuid: string, targetUuid: st
       donCard = p.don_attached.splice(attachedIdx, 1)[0]; 
       ownerPid = pid;
       
-      const oldTargetUuid = (donCard as any).attached_to;
+      const oldTargetUuid = donCard.attached_to;
       if (oldTargetUuid) {
         if (p.leader && p.leader.uuid === oldTargetUuid) { 
           p.leader.attached_don = Math.max(0, (p.leader.attached_don || 0) - 1); 
@@ -280,7 +281,7 @@ export const attachDonLocal = (state: GameState, donUuid: string, targetUuid: st
   
   if (targetFound) { 
     donCard.is_rest = false; 
-    (donCard as any).attached_to = targetUuid; 
+    donCard.attached_to = targetUuid; 
     player.don_attached.push(donCard); 
   } else { 
     player.don_active.push(donCard); 
@@ -331,7 +332,7 @@ export const resolveTurnEndLocal = (state: GameState): GameState => {
   nextPlayer.don_rested = [];
   nextPlayer.don_active.push(...nextPlayer.don_attached);
   nextPlayer.don_attached = [];
-  nextPlayer.don_active.forEach(d => { d.is_rest = false; (d as any).attached_to = null; });
+  nextPlayer.don_active.forEach(d => { d.is_rest = false; d.attached_to = null; });
 
   if (currentTurn > 1) {
     const deck = nextPlayer.zones.deck || [];
@@ -388,9 +389,9 @@ export const mulliganLocal = (state: GameState, playerId: string): GameState => 
 
 export const finishMulliganLocal = (state: GameState, playerId: string): GameState => {
   const newState = cloneState(state);
-  const flags = (newState as any).mulligan_finished || { p1: false, p2: false };
-  flags[playerId] = true;
-  (newState as any).mulligan_finished = flags;
+  const flags = newState.mulligan_finished || { p1: false, p2: false };
+  flags[playerId as 'p1' | 'p2'] = true;
+  newState.mulligan_finished = flags;
   return newState;
 };
 
@@ -421,7 +422,7 @@ export const resetGameLocal = (state: GameState): GameState => {
   const newState = cloneState(state);
   newState.turn_info.turn_count = 1;
   newState.turn_info.active_player_id = 'p1';
-  (newState as any).mulligan_finished = { p1: false, p2: false };
+  newState.mulligan_finished = { p1: false, p2: false };
 
   for (const pid of ['p1', 'p2'] as const) {
     const p = newState.players[pid];
@@ -449,7 +450,7 @@ export const resetGameLocal = (state: GameState): GameState => {
     allDons.forEach(d => {
       d.is_rest = false;
       d.is_face_up = false;
-      (d as any).attached_to = null;
+      d.attached_to = null;
     });
     p.zones.don_deck = allDons;
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -72,6 +72,13 @@ export type CardInstance = LeaderCard | CharacterCard | EventCard | StageCard | 
 // BoardSideでの互換性のため
 export type BoardCard = CardInstance;
 
+// 盤面の仮想ゾーン（ライフ束/デッキ/トラッシュ/ドン置き場）を1枚のカードとして描画する際の型。
+// 実カード(CardInstance)も渡せるよう全フィールドを optional にしている。
+export interface VirtualZoneCard extends Partial<BaseCard> {
+  id?: string;                 // デッキ/生データ由来の別ID表記
+  cards?: CardInstance[];      // トラッシュ等、内包カード一覧（ビューワー用）
+}
+
 export interface ZoneState {
   field: CardInstance[];
   hand: CardInstance[];

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -19,6 +19,31 @@ export interface BaseCard {
   trigger_text?: string;
   ability_disabled?: boolean;
   is_frozen?: boolean;
+  // ▼ ドン!!カードが付与されている対象キャラの uuid（未付与/解除時は null/undefined）
+  attached_to?: string | null;
+}
+
+// デッキ JSON / localStorage 由来の生カードデータ（スキーマ揺れを許容する permissive 型）。
+// card_id / uuid / id / number のいずれかで識別され得るため全て optional。
+export interface DeckCardData {
+  card_id?: string;
+  uuid?: string;
+  id?: string;
+  number?: string;
+  name?: string;
+  type?: string;
+  power?: number;
+  cost?: number;
+  counter?: number;
+  life?: number;
+  [key: string]: unknown;
+}
+
+// createInitialGameState 等が受け取るデッキ入力（leader は単体/配列の両形式を許容）。
+export interface DeckInput {
+  leader?: DeckCardData | DeckCardData[] | null;
+  cards?: DeckCardData[];
+  [key: string]: unknown;
 }
 
 export interface LeaderCard extends BaseCard {
@@ -99,6 +124,8 @@ export interface GameState {
     winner: string | null;
   };
   ready_states?: { p1: boolean; p2: boolean };
+  // マリガン完了フラグ（ローカル対戦用）
+  mulligan_finished?: { p1: boolean; p2: boolean };
   // RealGame.tsx 用
   active_battle?: {
     attacker_uuid: string;

--- a/src/screens/DeckBuilder.tsx
+++ b/src/screens/DeckBuilder.tsx
@@ -47,7 +47,7 @@ const getLocalDecks = (): DeckData[] => {
     return ids.map((id: string) => {
       const data = localStorage.getItem(`opcg_deck_${id}`);
       return data ? JSON.parse(data) : null;
-    }).filter((d: any) => d !== null);
+    }).filter((d: DeckData | null) => d !== null);
   } catch { return []; }
 };
 

--- a/src/screens/DeckBuilder.tsx
+++ b/src/screens/DeckBuilder.tsx
@@ -743,6 +743,7 @@ const CardCatalogScreen = ({ allCards, mode, currentDeck, onUpdateDeck, onClose,
   }, [allCards, filters, mode, searchText, currentDeck.leader_id, viewOnly, ownedCards]);
 
   useEffect(() => { 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- フィルタ/検索変更時に表示件数をリセットする意図的な同期
     setDisplayLimit(100); 
   }, [filters, mode, searchText]);
 

--- a/src/screens/DeckBuilder.tsx
+++ b/src/screens/DeckBuilder.tsx
@@ -201,23 +201,62 @@ const CardDetailScreen = ({ card, currentCount, onCountChange, onClose, onNaviga
   );
 };
 
+// フィルタ用の小コンポーネント群（再レンダリング毎の再生成による state 喪失を避けるため
+// モジュールスコープに定義する / react-hooks/static-components）。
+const SectionTitle = ({ children, onSelectAll }: { children: string, onSelectAll?: () => void }) => (
+  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '15px', marginBottom: '8px' }}>
+    <div style={{ color: '#aaa', fontSize: '12px', fontWeight: 'bold' }}>{children}</div>
+    {onSelectAll && (
+      <button
+        onClick={onSelectAll}
+        style={{ background: '#444', border: 'none', color: '#fff', fontSize: '10px', padding: '2px 8px', borderRadius: '4px', cursor: 'pointer' }}
+      >
+        全て選択
+      </button>
+    )}
+  </div>
+);
+
+const FilterBtn = ({ label, active, onClick, color }: { label: string, active: boolean, onClick: () => void, color?: string }) => (
+  <button
+    onClick={onClick}
+    style={{
+      padding: '8px 12px',
+      borderRadius: '20px',
+      border: active ? `2px solid ${color || '#3498db'}` : '1px solid #555',
+      background: active ? (color || '#3498db') : '#333',
+      color: 'white',
+      fontSize: '12px',
+      fontWeight: active ? 'bold' : 'normal',
+      cursor: 'pointer',
+      minWidth: '40px'
+    }}
+  >
+    {label}
+  </button>
+);
+
+const ColorBtn = ({ label, colorCode, isActive, anySelected, onToggle }: { label: string, colorCode: string, isActive: boolean, anySelected: boolean, onToggle: () => void }) => (
+  <div
+    title={label}
+    onClick={onToggle}
+    style={{
+      width: '40px', height: '40px', borderRadius: '50%',
+      background: colorCode,
+      border: isActive ? '3px solid white' : '2px solid transparent',
+      boxShadow: isActive ? '0 0 10px white' : 'none',
+      cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      color: 'black', fontWeight: 'bold', fontSize: '10px',
+      opacity: (!anySelected || isActive) ? 1 : 0.4
+    }}
+  >
+    {isActive && "✓"}
+  </div>
+);
+
 const FilterModal = ({ initialFilters, onApply, traitList, setList, blockIconList, onClose, showOwnership }: { initialFilters: FilterState, onApply: (f: FilterState) => void, traitList: string[], setList: string[], blockIconList: string[], onClose: () => void, showOwnership?: boolean }) => {
   const [localFilters, setLocalFilters] = useState<FilterState>(initialFilters);
   const [traitSearch, setTraitSearch] = useState('');
-
-  const SectionTitle = ({ children, onSelectAll }: { children: string, onSelectAll?: () => void }) => (
-    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '15px', marginBottom: '8px' }}>
-      <div style={{ color: '#aaa', fontSize: '12px', fontWeight: 'bold' }}>{children}</div>
-      {onSelectAll && (
-        <button 
-          onClick={onSelectAll}
-          style={{ background: '#444', border: 'none', color: '#fff', fontSize: '10px', padding: '2px 8px', borderRadius: '4px', cursor: 'pointer' }}
-        >
-          全て選択
-        </button>
-      )}
-    </div>
-  );
 
   const toggle = (key: keyof FilterState, value: string) => {
     const current = localFilters[key];
@@ -231,46 +270,6 @@ const FilterModal = ({ initialFilters, onApply, traitList, setList, blockIconLis
     setLocalFilters({
       color: [], type: [], attribute: [], traits: [], counter: [], cost: [], power: [], trigger: [], sets: [], block_icon: [], sort: 'COST', ownership: 'ALL'
     });
-  };
-
-  const FilterBtn = ({ label, active, onClick, color }: { label: string, active: boolean, onClick: () => void, color?: string }) => (
-    <button 
-      onClick={onClick}
-      style={{
-        padding: '8px 12px',
-        borderRadius: '20px',
-        border: active ? `2px solid ${color || '#3498db'}` : '1px solid #555',
-        background: active ? (color || '#3498db') : '#333',
-        color: 'white',
-        fontSize: '12px',
-        fontWeight: active ? 'bold' : 'normal',
-        cursor: 'pointer',
-        minWidth: '40px'
-      }}
-    >
-      {label}
-    </button>
-  );
-
-  const ColorBtn = ({ colorKey, label, colorCode }: { colorKey: string, label: string, colorCode: string }) => {
-    const isActive = localFilters.color.includes(colorKey);
-    return (
-      <div 
-        title={label}
-        onClick={() => toggle('color', colorKey)}
-        style={{
-          width: '40px', height: '40px', borderRadius: '50%',
-          background: colorCode,
-          border: isActive ? '3px solid white' : '2px solid transparent',
-          boxShadow: isActive ? '0 0 10px white' : 'none',
-          cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
-          color: 'black', fontWeight: 'bold', fontSize: '10px',
-          opacity: (localFilters.color.length === 0 || isActive) ? 1 : 0.4
-        }}
-      >
-        {isActive && "✓"}
-      </div>
-    );
   };
 
   const filteredTraits = useMemo(() => {
@@ -316,12 +315,16 @@ const FilterModal = ({ initialFilters, onApply, traitList, setList, blockIconLis
 
           <SectionTitle onSelectAll={() => setLocalFilters({...localFilters, color: ['Red', 'Green', 'Blue', 'Purple', 'Black', 'Yellow']})}>色 (COLOR)</SectionTitle>
           <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-            <ColorBtn colorKey="Red" label="赤" colorCode="#e74c3c" />
-            <ColorBtn colorKey="Green" label="緑" colorCode="#27ae60" />
-            <ColorBtn colorKey="Blue" label="青" colorCode="#3498db" />
-            <ColorBtn colorKey="Purple" label="紫" colorCode="#9b59b6" />
-            <ColorBtn colorKey="Black" label="黒" colorCode="#34495e" />
-            <ColorBtn colorKey="Yellow" label="黄" colorCode="#f1c40f" />
+            {([['Red', '赤', '#e74c3c'], ['Green', '緑', '#27ae60'], ['Blue', '青', '#3498db'], ['Purple', '紫', '#9b59b6'], ['Black', '黒', '#34495e'], ['Yellow', '黄', '#f1c40f']] as const).map(([colorKey, label, colorCode]) => (
+              <ColorBtn
+                key={colorKey}
+                label={label}
+                colorCode={colorCode}
+                isActive={localFilters.color.includes(colorKey)}
+                anySelected={localFilters.color.length > 0}
+                onToggle={() => toggle('color', colorKey)}
+              />
+            ))}
           </div>
 
           <SectionTitle onSelectAll={() => setLocalFilters({...localFilters, cost: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']})}>コスト (COST)</SectionTitle>
@@ -411,6 +414,23 @@ const FilterModal = ({ initialFilters, onApply, traitList, setList, blockIconLis
   );
 };
 
+const StatSection = ({ title, data }: { title: string, data: [string, number][] }) => (
+  <div style={{ marginBottom: '20px' }}>
+    <div style={{ fontSize: '14px', fontWeight: 'bold', borderLeft: '3px solid #e74c3c', paddingLeft: '8px', marginBottom: '10px' }}>{title}</div>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      {data.map(([key, count]) => (
+        <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <div style={{ width: '60px', fontSize: '12px' }}>{key}</div>
+          <div style={{ flex: 1, height: '12px', background: '#444', borderRadius: '6px', overflow: 'hidden' }}>
+            <div style={{ width: `${(count / 50) * 100}%`, height: '100%', background: '#3498db' }} />
+          </div>
+          <div style={{ width: '30px', fontSize: '12px', textAlign: 'right' }}>{count}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
 const DeckDistributionModal = ({ deck, allCards, onClose }: { deck: DeckData, allCards: CardData[], onClose: () => void }) => {
   const stats = useMemo(() => {
     const cards = deck.card_uuids.map(uuid => allCards.find(c => c.uuid === uuid)).filter(Boolean) as CardData[];
@@ -432,23 +452,6 @@ const DeckDistributionModal = ({ deck, allCards, onClose }: { deck: DeckData, al
       traits: Object.entries(traits).sort((a, b) => b[1] - a[1]).slice(0, 10)
     };
   }, [deck.card_uuids, allCards]);
-
-  const StatSection = ({ title, data }: { title: string, data: [string, number][] }) => (
-    <div style={{ marginBottom: '20px' }}>
-      <div style={{ fontSize: '14px', fontWeight: 'bold', borderLeft: '3px solid #e74c3c', paddingLeft: '8px', marginBottom: '10px' }}>{title}</div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-        {data.map(([key, count]) => (
-          <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-            <div style={{ width: '60px', fontSize: '12px' }}>{key}</div>
-            <div style={{ flex: 1, height: '12px', background: '#444', borderRadius: '6px', overflow: 'hidden' }}>
-              <div style={{ width: `${(count / 50) * 100}%`, height: '100%', background: '#3498db' }} />
-            </div>
-            <div style={{ width: '30px', fontSize: '12px', textAlign: 'right' }}>{count}</div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
 
   return (
     <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.85)', zIndex: 110, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '20px' }}>

--- a/src/screens/RealGame.tsx
+++ b/src/screens/RealGame.tsx
@@ -94,7 +94,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
         const res = await fetch(`${API_CONFIG.BASE_URL}/api/deck/list`);
         const data = await res.json();
         if (data.success) {
-          data.decks.forEach((d: any) => {
+          data.decks.forEach((d: { id: string; name: string; leader_id?: string }) => {
             const id = d.id.endsWith('.json') ? d.id : `db:${d.id}`;
             options.push({ id, name: d.name, leaderId: d.leader_id });
           });
@@ -123,7 +123,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     const battleActionTypes = Object.values(CONST.c_to_s_interface.BATTLE_ACTIONS.TYPES);
     
     if (battleActionTypes.includes(pendingRequest.action)) {
-      await sendBattleAction(pendingRequest.action as any, selectedUuids[0], pendingRequest.request_id);
+      await sendBattleAction(pendingRequest.action, selectedUuids[0], pendingRequest.request_id);
     } else {
       await sendAction(CONST.c_to_s_interface.GAME_ACTIONS.TYPES.RESOLVE_EFFECT_SELECTION, {
         extra: { selected_uuids: selectedUuids }
@@ -155,7 +155,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     });
   };
 
-  const handleAction = async (type: string, payload: { uuid?: string; target_ids?: string[]; extra?: any } = {}) => {
+  const handleAction = async (type: string, payload: { uuid?: string; target_ids?: string[]; extra?: Record<string, unknown> } = {}) => {
     if (!gameState?.game_id || isPending) return;
 
     if (type === CONST.c_to_s_interface.GAME_ACTIONS.TYPES.ATTACK) {
@@ -180,7 +180,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     }
     
     if (type === CONST.c_to_s_interface.GAME_ACTIONS.TYPES.ATTACK_CONFIRM) {
-      await sendAction(type as any, {
+      await sendAction(type, {
         card_id: payload.uuid,
         target_ids: payload.target_ids,
       }); 
@@ -189,7 +189,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
       return;
     }
 
-    await sendAction(type as any, {
+    await sendAction(type, {
       card_id: payload.uuid,
       target_ids: payload.target_ids,
       extra: payload.extra
@@ -207,12 +207,12 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
 
   const handleMulligan = async () => {
     if (!gameState?.game_id || isPending) return;
-    await sendAction('MULLIGAN' as any, {});
+    await sendAction('MULLIGAN', {});
   };
 
   const handleKeepHand = async () => {
     if (!gameState?.game_id || isPending) return;
-    await sendAction('KEEP_HAND' as any, {});
+    await sendAction('KEEP_HAND', {});
   };
 
   const handleTurnEnd = () => {
@@ -226,8 +226,8 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     ...(gameState.players.p2.zones.hand.map(c => c.uuid)),
     ...(gameState.players.p1.leader ? [gameState.players.p1.leader.uuid] : []),
     ...(gameState.players.p2.leader ? [gameState.players.p2.leader.uuid] : []),
-    ...(gameState.players.p1.stage ? [(gameState.players.p1.stage as any).uuid] : []),
-    ...(gameState.players.p2.stage ? [(gameState.players.p2.stage as any).uuid] : []),
+    ...(gameState.players.p1.stage ? [gameState.players.p1.stage.uuid] : []),
+    ...(gameState.players.p2.stage ? [gameState.players.p2.stage.uuid] : []),
   ]) : new Set<string>();
 
   const isBoardSelectMode =
@@ -269,7 +269,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
       const isValidTarget =
         opp.leader?.uuid === card.uuid ||
         opp.zones.field.some(c => c.uuid === card.uuid) ||
-        (opp.stage as any)?.uuid === card.uuid;
+        opp.stage?.uuid === card.uuid;
       if (!isValidTarget) {
         return; // 無効な対象クリックは無視（ターゲティングは継続）
       }
@@ -573,7 +573,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
   );
 
   const activeDonCount = gameState && activePlayerId 
-    ? (gameState.players[activePlayerId] as any).don_active.length 
+    ? gameState.players[activePlayerId].don_active.length 
     : 0;
 
   return (
@@ -639,7 +639,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
             手札を確認してください。マリガンを選ぶと<br />手札5枚を全てデッキに戻し、引き直します。
           </p>
           <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', justifyContent: 'center', maxWidth: '500px' }}>
-            {(pendingRequest.candidates || []).map((card: any) => (
+            {(pendingRequest.candidates || []).map((card: CardInstance) => (
               <div
                 key={card.uuid}
                 style={{
@@ -847,9 +847,9 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
             </div>
           )}
 
-          {(pendingRequest as any).options && (
+          {pendingRequest.options && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '10px' }}>
-              {(pendingRequest as any).options.map((label: string, idx: number) => (
+              {(pendingRequest.options as unknown as string[]).map((label: string, idx: number) => (
                 <button
                   key={idx}
                   onClick={() => handleOptionSelect(idx)}

--- a/src/screens/RealGame.tsx
+++ b/src/screens/RealGame.tsx
@@ -360,6 +360,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
       setIsAttackTargeting(false);
       setAttackingCardUuid(null);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- request_id 変化時のみ実行する意図（pendingRequest/isAttackTargeting は最新値を本体で参照）
   }, [pendingRequest?.request_id]);
 
   useEffect(() => {
@@ -393,6 +394,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
       window.removeEventListener('resize', handleResize);
       app.destroy(true, { children: true });
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- PIXI app の初期化はマウント時(=isSetupComplete)に1回のみ。startGame等の再実行は不要
   }, [isSetupComplete]);
 
   useEffect(() => {
@@ -436,6 +438,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     };
 
     renderScene();
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- 描画は列挙した盤面状態の変化時のみ再実行する意図。定数/コールバックは最新を本体で参照
   }, [gameState, activePlayerId, isAttackTargeting, attackingCardUuid, pendingRequest, boardSelected]);
 
   useEffect(() => {

--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -10,13 +10,13 @@ import { CardDetailSheet } from '../ui/CardDetailSheet';
 import { CardSelectModal } from '../ui/CardSelectModal';
 import { DeckSelectModal, type DeckOption } from '../ui/DeckSelectModal';
 import { apiClient } from '../api/client';
-import type { GameState, CardInstance } from '../game/types';
+import type { GameState, CardInstance, PlayerState, DeckInput } from '../game/types';
 import { API_CONFIG } from '../api/api.config';
 import { logger } from '../utils/logger';
 import { handleLocalAction } from '../game/localActionHandler';
 import { getCardImageUrl } from '../utils/imageAssets';
 
-const MOCK_DECKS: Record<string, any> = {
+const MOCK_DECKS: Record<string, DeckInput> = {
   'imu.json': {
     leader: { name: "イム", card_id: "ST01-001", power: 5000, type: "LEADER", life: 5 },
     cards: Array.from({ length: 50 }, (_, i) => ({
@@ -192,7 +192,7 @@ export const SandboxGame = ({
   const inspectScrollXRef = useRef(20);
   const { COLORS } = LAYOUT_CONSTANTS;
 
-  const longPressTimerRef = useRef<any>(null);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pressStartPosRef = useRef<{x: number, y: number} | null>(null);
   
   const pendingDragRef = useRef<{ card: CardInstance, x: number, y: number } | null>(null);
@@ -241,7 +241,7 @@ export const SandboxGame = ({
 
   const mulliganStatus = useMemo(() => {
     if (!gameState) return { p1: false, p2: false };
-    return (gameState as any).mulligan_finished || { p1: false, p2: false };
+    return gameState.mulligan_finished || { p1: false, p2: false };
   }, [gameState]);
 
   const isMulliganPhase = useMemo(() => {
@@ -297,7 +297,7 @@ export const SandboxGame = ({
         const res = await fetch(`${API_CONFIG.BASE_URL}/api/deck/list`);
         const data = await res.json();
         if (data.success) {
-          data.decks.forEach((d: any) => {
+          data.decks.forEach((d: { id: string; name: string; leader_id?: string }) => {
             const id = d.id.endsWith('.json') ? d.id : `db:${d.id}`;
             options.push({ id, name: d.name, leaderId: d.leader_id });
           });
@@ -339,12 +339,12 @@ export const SandboxGame = ({
             name: initialP1DeckId || '',
             player_id: 'p1',
             zones: { hand: [], field: [], life: [], trash: [] }
-          } as any,
+          } as unknown as PlayerState,
           p2: {
             name: initialP2DeckId || '',
             player_id: 'p2',
             zones: { hand: [], field: [], life: [], trash: [] }
-          } as any
+          } as unknown as PlayerState
         },
         turn_info: { turn_count: 0, active_player_id: 'p1', current_phase: 'SETUP', winner: null }
       });
@@ -530,7 +530,7 @@ export const SandboxGame = ({
         const overlay = createInspectOverlay(
           inspecting.type, inspectingCards, revealedCardIds, W, H, inspectScrollXRef.current, 
           () => setInspecting(null), 
-          (card, startPos) => onCardDown({ global: startPos } as any, card),
+          (card, startPos) => onCardDown({ global: startPos } as unknown as PIXI.FederatedPointerEvent, card),
           (uuid) => { 
               if (longPressTriggeredRef.current) return;
               const newSet = new Set(revealedCardIds); 
@@ -745,12 +745,12 @@ export const SandboxGame = ({
 
             const destP = destPid === 'p1' ? gameState?.players.p1 : gameState?.players.p2;
             
-            const findInStack = (p: any) => { if (p.zones.deck?.some((c: any) => c.uuid === card.uuid)) return { type: 'deck' }; if (p.zones.life?.some((c: any) => c.uuid === card.uuid)) return { type: 'life' }; if (p.zones.trash?.some((c: any) => c.uuid === card.uuid)) return { type: 'trash' }; return null; };
+            const findInStack = (p: PlayerState) => { if (p.zones.deck?.some((c: CardInstance) => c.uuid === card.uuid)) return { type: 'deck' as const }; if (p.zones.life?.some((c: CardInstance) => c.uuid === card.uuid)) return { type: 'life' as const }; if (p.zones.trash?.some((c: CardInstance) => c.uuid === card.uuid)) return { type: 'trash' as const }; return null; };
             if (destP) { 
                 const stackInfo = findInStack(destP); 
                 if (stackInfo) { 
                     inspectScrollXRef.current = 20; 
-                    setInspecting({ type: stackInfo.type as any, pid: destPid }); 
+                    setInspecting({ type: stackInfo.type, pid: destPid }); 
                     setRevealedCardIds(new Set()); 
                     return; 
                 } 
@@ -802,13 +802,13 @@ export const SandboxGame = ({
     }
   };
 
-  const handleAction = async (type: string, params: any) => {
+  const handleAction = async (type: string, params: Record<string, unknown>) => {
       if (isPending || !gameState) return;
       if (!isLocalMode && !activeGameId) return;
       setIsPending(true);
       try { 
           const localParams = { ...params };
-          const pid = myPlayerId === 'both' ? (params.player_id || 'p1') : myPlayerId;
+          const pid = myPlayerId === 'both' ? ((params.player_id as string) || 'p1') : myPlayerId;
 
           const getDeckData = async (deckId: string) => {
               if (!deckId) return { leader: [], cards: [] };
@@ -826,7 +826,7 @@ export const SandboxGame = ({
               return finalData;
           };
 
-          const normalizeDeckData = (data: any) => {
+          const normalizeDeckData = (data: DeckInput & { deck?: DeckInput }) => {
             if (!data) return { leader: null, cards: [] };
             let leader = data.leader;
             if (Array.isArray(leader)) {
@@ -847,7 +847,7 @@ export const SandboxGame = ({
           };
 
           if (isLocalMode && type === 'SET_DECK') {
-              const rawData = await getDeckData(params.deck_id);
+              const rawData = await getDeckData(params.deck_id as string);
               localParams.deckData = normalizeDeckData(rawData);
           }
 
@@ -859,7 +859,7 @@ export const SandboxGame = ({
               localParams.p2Deck = normalizeDeckData(d2);
           }
 
-          const newState = handleLocalAction(gameState, type, { ...localParams, player_id: pid });
+          const newState = handleLocalAction(gameState, type, { ...localParams, player_id: pid } as Parameters<typeof handleLocalAction>[2]);
           setGameState(newState);
 
           if (!isLocalMode) {

--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -412,6 +412,7 @@ export const SandboxGame = ({
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
       if (wsRef.current) { wsRef.current.onclose = null; wsRef.current.close(); wsRef.current = null; }
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- WebSocket接続/初期化はマウント時に1回のみ。onBack/onForceBack等は最新を本体で参照
   }, [isLocalMode, initialP1DeckId, initialP2DeckId]); 
 
   const hasAutoStartedRef = useRef(false);
@@ -429,6 +430,7 @@ export const SandboxGame = ({
         handleAction('START', {});
       }, 100);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- 自動開始は gameState 等の変化時のみ。handleAction は最新を本体で参照
   }, [gameState, isLocalMode, initialP1DeckId, initialP2DeckId]);
 
   // 進行中ゲームの永続化: ローカルモードでPLAYING中はgameStateをsessionStorageへ保存し、
@@ -483,6 +485,7 @@ export const SandboxGame = ({
         } catch(e) { console.warn(e); }
         appRef.current = null;
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- 描画は status 変化時のみ再実行する意図（COLORS は定数）
   }, [gameState?.status]);
 
   useEffect(() => {
@@ -557,6 +560,7 @@ export const SandboxGame = ({
     }
 
     if (dragState) app.stage.addChild(dragState.sprite);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- 描画は列挙した状態の変化時のみ。handleAction/COLORS は最新/定数を本体で参照
   }, [gameState, isPending, dragState, inspecting, isRotated, myPlayerId, inspectingCards, revealedCardIds, isActionBlockedByMulligan, startDrag]);
 
   useEffect(() => {
@@ -763,6 +767,7 @@ export const SandboxGame = ({
     };
     window.addEventListener('pointermove', onPointerMove); window.addEventListener('pointerup', onPointerUp);
     return () => { window.removeEventListener('pointermove', onPointerMove); window.removeEventListener('pointerup', onPointerUp); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- ドラッグ系ハンドラ登録は列挙状態の変化時のみ。handleAction は最新を本体で参照
   }, [dragState, gameState, inspecting, isRotated, myPlayerId, inspectingCards, revealedCardIds, isActionBlockedByMulligan, startDrag]);
 
   const handleReplacement = async (trashCardUuids: string[]) => {

--- a/src/ui/BoardSide.tsx
+++ b/src/ui/BoardSide.tsx
@@ -1,7 +1,7 @@
 import * as PIXI from 'pixi.js';
 import type { LayoutCoords } from '../layout/layoutEngine';
 import { createCardContainer } from './CardRenderer';
-import type { PlayerState, CardInstance, BoardCard } from '../game/types';
+import type { PlayerState, CardInstance, BoardCard, VirtualZoneCard } from '../game/types';
 import { logger } from '../utils/logger';
 // 未使用のインポートを削除しました
 
@@ -35,7 +35,7 @@ export const createBoardSide = (
     }
   };
 
-  const getCardOpts = (c: Partial<CardInstance>) => ({
+  const getCardOpts = (c: VirtualZoneCard) => ({
     onClick: () => onCardClick(c as CardInstance),
     isOpponent: isOpponent,
     isSelectable: selectableUuids?.has(c.uuid || '') ?? false,
@@ -99,20 +99,20 @@ export const createBoardSide = (
   // ライフ (getX適用)
   const lifeCount = z.life?.length || 0;
   const life = createCardContainer(
-    { uuid: `life-${p.player_id}`, name: 'Life' } as any, 
+    { uuid: `life-${p.player_id}`, name: 'Life' } as VirtualZoneCard, 
     coords.CW, 
     coords.CH, 
-    { ...getCardOpts({ uuid: `life-${p.player_id}`, name: 'Life' } as any), count: lifeCount }
+    { ...getCardOpts({ uuid: `life-${p.player_id}`, name: 'Life' } as VirtualZoneCard), count: lifeCount }
   );
   life.x = getX(coords.getLifeX(W)); life.y = r2Y;
   side.addChild(life);
 
   // デッキ (getX適用)
   const deck = createCardContainer(
-    { uuid: `deck-${p.player_id}`, name: 'Deck' } as any, 
+    { uuid: `deck-${p.player_id}`, name: 'Deck' } as VirtualZoneCard, 
     coords.CW, 
     coords.CH, 
-    { ...getCardOpts({ uuid: `deck-${p.player_id}`, name: 'Deck' } as any) }
+    { ...getCardOpts({ uuid: `deck-${p.player_id}`, name: 'Deck' } as VirtualZoneCard) }
   );
   deck.x = getX(coords.getDeckX(W)); deck.y = r2Y;
   side.addChild(deck);
@@ -127,43 +127,43 @@ export const createBoardSide = (
       name: 'Trash', 
       cards: z.trash,
       card_id: topTrashCard ? topTrashCard.card_id : undefined
-    } as any, 
+    } as VirtualZoneCard, 
     smallCW, // 変更
     smallCH, // 変更
-    { ...getCardOpts({ uuid: `trash-${p.player_id}`, name: 'Trash', cards: z.trash } as any), count: trashCount }
+    { ...getCardOpts({ uuid: `trash-${p.player_id}`, name: 'Trash', cards: z.trash } as VirtualZoneCard), count: trashCount }
   );
   trash.x = getX(coords.getTrashX(W)); trash.y = r3Y;
   side.addChild(trash);
 
   // ドン!!デッキ (Sandbox仕様: サイズ縮小 + getX適用)
-  const donDeckCount = (p as any).don_deck_count ?? 0;
+  const donDeckCount = p.don_deck_count ?? 0;
   const donDeck = createCardContainer(
-    { uuid: `dondeck-${p.player_id}`, name: 'Don!! Deck' } as any, 
+    { uuid: `dondeck-${p.player_id}`, name: 'Don!! Deck' } as VirtualZoneCard, 
     smallCW, // 変更
     smallCH, // 変更
-    { ...getCardOpts({ uuid: `dondeck-${p.player_id}`, name: 'Don!! Deck' } as any), count: donDeckCount }
+    { ...getCardOpts({ uuid: `dondeck-${p.player_id}`, name: 'Don!! Deck' } as VirtualZoneCard), count: donDeckCount }
   );
   donDeck.x = getX(coords.getDonDeckX(W)); donDeck.y = r3Y;
   side.addChild(donDeck);
 
   // アクティブドン (Sandbox仕様: サイズ縮小 + getX適用)
-  const donActiveList = (p as any).don_active || [];
+  const donActiveList = p.don_active || [];
   const donActiveCount = donActiveList.length;
   const donActive = createCardContainer(
     { 
       uuid: `donactive-${p.player_id}`, 
       name: 'Don!! Active',
       card_id: 'DON' 
-    } as any, 
+    } as VirtualZoneCard, 
     smallCW, // 変更
     smallCH, // 変更
-    { ...getCardOpts({ uuid: `donactive-${p.player_id}`, name: 'Don!! Active' } as any), count: donActiveCount }
+    { ...getCardOpts({ uuid: `donactive-${p.player_id}`, name: 'Don!! Active' } as VirtualZoneCard), count: donActiveCount }
   );
   donActive.x = getX(coords.getDonActiveX(W)); donActive.y = r3Y;
   side.addChild(donActive);
 
   // レストドン (Sandbox仕様: サイズ縮小 + getX適用)
-  const donRestList = (p as any).don_rested || [];
+  const donRestList = p.don_rested || [];
   const donRestCount = donRestList.length;
   const donRest = createCardContainer(
     { 
@@ -171,10 +171,10 @@ export const createBoardSide = (
       name: 'Don!! Rest', 
       is_rest: true,
       card_id: 'DON'
-    } as any, 
+    } as VirtualZoneCard, 
     smallCW, // 変更
     smallCH, // 変更
-    { ...getCardOpts({ uuid: `donrest-${p.player_id}`, name: 'Don!! Rest' } as any), count: donRestCount }
+    { ...getCardOpts({ uuid: `donrest-${p.player_id}`, name: 'Don!! Rest' } as VirtualZoneCard), count: donRestCount }
   );
   donRest.x = getX(coords.getDonRestX(W)); donRest.y = r3Y;
   side.addChild(donRest);

--- a/src/ui/CardDetailSheet.tsx
+++ b/src/ui/CardDetailSheet.tsx
@@ -11,7 +11,7 @@ interface CardDetailSheetProps {
   location: string;
   isMyTurn: boolean;
   activeDonCount?: number;
-  onAction: (type: string, payload: any) => Promise<void>;
+  onAction: (type: string, payload: Record<string, unknown>) => Promise<void>;
   onClose: () => void;
 }
 
@@ -34,7 +34,7 @@ export const CardDetailSheet: React.FC<CardDetailSheetProps> = ({ card, location
 
   const ACTIONS = CONST.c_to_s_interface.GAME_ACTIONS.TYPES;
 
-  const handleExecute = async (type: string, extra: any = {}) => {
+  const handleExecute = async (type: string, extra: Record<string, unknown> = {}) => {
     logger.log({
       level: 'info',
       action: "trace.handleExecute_called",
@@ -155,7 +155,7 @@ export const CardDetailSheet: React.FC<CardDetailSheetProps> = ({ card, location
   });
 
   // ▼ 変更: getCardImageUrlを使用
-  const mainImageUrl = ('card_id' in card) ? getCardImageUrl((card as any).card_id) : null;
+  const mainImageUrl = ('card_id' in card) ? getCardImageUrl((card as { card_id: string }).card_id) : null;
 
   if (card.cards && card.cards.length > 0) {
     return (

--- a/src/ui/CardRenderer.tsx
+++ b/src/ui/CardRenderer.tsx
@@ -1,4 +1,5 @@
 import * as PIXI from 'pixi.js';
+import type { VirtualZoneCard } from '../game/types';
 import { LAYOUT_CONSTANTS, LAYOUT_PARAMS } from '../layout/layout.config';
 import { GAME_UI_CONFIG } from '../game/game.config';
 import { logger } from '../utils/logger';
@@ -7,8 +8,20 @@ import { getCardImageUrl, getBackImageUrl } from '../utils/imageAssets';
 const { COLORS, SIZES } = LAYOUT_CONSTANTS;
 const { SHAPE, UI_DETAILS, PHYSICS } = LAYOUT_PARAMS;
 
+// カード描画で使うテキストスタイル（config 由来の string fontWeight 等を許容する緩めの型）。
+// PIXI.Text へ渡す際は ITextStyle としてキャストする。
+type CardTextStyle = {
+  fontSize?: number;
+  fill?: string | number;
+  fontWeight?: string;
+  stroke?: string | number;
+  strokeThickness?: number;
+  align?: string;
+  [key: string]: unknown;
+};
+
 export const createCardContainer = (
-  card: any,
+  card: VirtualZoneCard,
   cw: number,
   ch: number,
   options: { count?: number; onClick: () => void; isOpponent?: boolean; isSelectable?: boolean; isSelected?: boolean }
@@ -117,12 +130,12 @@ export const createCardContainer = (
 
   if (isEmpty) return container;
 
-  const addText = (content: string, style: any, x: number, y: number, rotationMode: 'screen' | 'card' | number = 'screen') => {
-    const txt = new PIXI.Text(content, style);
+  const addText = (content: string, style: CardTextStyle, x: number, y: number, rotationMode: 'screen' | 'card' | number = 'screen') => {
+    const txt = new PIXI.Text(content, style as Partial<PIXI.ITextStyle>);
     if (!isBack && imageUrl && style.fill !== '#ffffff') {
       style.stroke = '#000000';
       style.strokeThickness = 3;
-      txt.style = style;
+      txt.style = style as Partial<PIXI.ITextStyle>;
     }
 
     const maxWidth = isRest ? ch * UI_DETAILS.CARD_TEXT_MAX_WIDTH_RATIO : cw * UI_DETAILS.CARD_TEXT_MAX_WIDTH_RATIO;
@@ -231,7 +244,7 @@ export const createCardContainer = (
     }
 
     // 4. ドン!!付与数 (右下)
-    if (card?.attached_don > 0) {
+    if ((card?.attached_don ?? 0) > 0) {
       const bx = isOpponent ? (-cw / 2 + UI_DETAILS.CARD_BADGE_DON_OFFSET) : (cw / 2 - UI_DETAILS.CARD_BADGE_DON_OFFSET);
       const by = isOpponent ? (-ch / 2 + UI_DETAILS.CARD_BADGE_DON_OFFSET) : (ch / 2 - UI_DETAILS.CARD_BADGE_DON_OFFSET);
       const donBadge = new PIXI.Graphics()

--- a/src/ui/CardSelectModal.tsx
+++ b/src/ui/CardSelectModal.tsx
@@ -34,6 +34,7 @@ export const CardSelectModal: React.FC<CardSelectModalProps> = ({
   // 並び替えモードでは全選択可能カードを初期順序で確定対象にする。
   useEffect(() => {
     if (isOrderMode) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 並び替えモード移行時に確定対象を初期化する意図的な同期
       setSelected(selectableCards.map(c => c.uuid));
     }
   }, [isOrderMode, candidates]);  // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/ui/SandboxBoardSide.tsx
+++ b/src/ui/SandboxBoardSide.tsx
@@ -41,7 +41,7 @@ export const createSandboxBoardSide = (
     container.eventMode = 'static';
     container.cursor = 'grab';
     
-    let pressTimer: any = null;
+    let pressTimer: ReturnType<typeof setTimeout> | null = null;
     let startPos = { x: 0, y: 0 };
 
     const startPress = (e: PIXI.FederatedPointerEvent) => {

--- a/src/ui/SandboxBoardSide.tsx
+++ b/src/ui/SandboxBoardSide.tsx
@@ -1,7 +1,7 @@
 import * as PIXI from 'pixi.js';
 import type { LayoutCoords } from '../layout/layoutEngine';
 import { createCardContainer } from './CardRenderer';
-import type { PlayerState, CardInstance, BoardCard } from '../game/types';
+import type { PlayerState, CardInstance, BoardCard, VirtualZoneCard } from '../game/types';
 
 export const createSandboxBoardSide = (
   p: PlayerState, 
@@ -32,7 +32,7 @@ export const createSandboxBoardSide = (
     }
   };
 
-  const getCardOpts = (_c: Partial<CardInstance>) => ({ 
+  const getCardOpts = (_c: VirtualZoneCard) => ({ 
     onClick: () => {}, 
     isOpponent: false 
   });
@@ -108,7 +108,7 @@ export const createSandboxBoardSide = (
   // リーダー
   let leaderCard = p.leader;
   if (Array.isArray(leaderCard)) {
-    leaderCard = (leaderCard as any)[0];
+    leaderCard = (leaderCard as unknown as (typeof leaderCard)[])[0];
   }
 
   if (leaderCard) {
@@ -130,7 +130,7 @@ export const createSandboxBoardSide = (
 
   // ライフ
   const lifeList = z.life || [];
-  const lifeCard = { uuid: `life-${p.player_id}`, name: 'Life' } as any;
+  const lifeCard = { uuid: `life-${p.player_id}`, name: 'Life' } as VirtualZoneCard;
   const life = createCardContainer(lifeCard, coords.CW, coords.CH, { 
       ...getCardOpts(lifeCard), 
       count: lifeList.length
@@ -142,7 +142,7 @@ export const createSandboxBoardSide = (
 
   // デッキ
   const deckList = z.deck || [];
-  const deckCard = { uuid: `deck-${p.player_id}`, name: 'Deck' } as any;
+  const deckCard = { uuid: `deck-${p.player_id}`, name: 'Deck' } as VirtualZoneCard;
   const deck = createCardContainer(deckCard, coords.CW, coords.CH, {
       ...getCardOpts(deckCard)
   });
@@ -154,9 +154,9 @@ export const createSandboxBoardSide = (
   // トラッシュ (70%サイズ)
   const topTrash = z.trash && z.trash.length > 0 ? z.trash[z.trash.length - 1] : null;
   const trash = createCardContainer(
-    { uuid: `trash-${p.player_id}`, name: 'Trash', card_id: topTrash?.card_id } as any, 
+    { uuid: `trash-${p.player_id}`, name: 'Trash', card_id: topTrash?.card_id } as VirtualZoneCard, 
     smallCW, smallCH, 
-    { ...getCardOpts({} as any), count: z.trash?.length || 0 }
+    { ...getCardOpts({} as VirtualZoneCard), count: z.trash?.length || 0 }
   );
   trash.x = getX(coords.getTrashX(W)); trash.y = r3Y;
   if (topTrash) setupInteractive(trash, topTrash);
@@ -164,11 +164,11 @@ export const createSandboxBoardSide = (
 
   // ドン!!デッキ (70%サイズ)
   const donDeckList = z.don_deck || []; 
-  const donDeckCount = (p as any).don_deck_count ?? donDeckList.length;
+  const donDeckCount = p.don_deck_count ?? donDeckList.length;
   const donDeck = createCardContainer(
-    { uuid: `dondeck-${p.player_id}`, name: 'Don!! Deck' } as any, 
+    { uuid: `dondeck-${p.player_id}`, name: 'Don!! Deck' } as VirtualZoneCard, 
     smallCW, smallCH, 
-    { ...getCardOpts({} as any), count: donDeckCount }
+    { ...getCardOpts({} as VirtualZoneCard), count: donDeckCount }
   );
   donDeck.x = getX(coords.getDonDeckX(W)); donDeck.y = r3Y;
   const topDon = donDeckList.length > 0 ? donDeckList[0] : null;
@@ -176,11 +176,11 @@ export const createSandboxBoardSide = (
   side.addChild(donDeck);
 
   // アクティブドン (70%サイズ)
-  const donActiveList = (p as any).don_active || [];
+  const donActiveList = p.don_active || [];
   const donActive = createCardContainer(
-    { uuid: `donactive-${p.player_id}`, name: 'Don!! Active', card_id: 'DON' } as any, 
+    { uuid: `donactive-${p.player_id}`, name: 'Don!! Active', card_id: 'DON' } as VirtualZoneCard, 
     smallCW, smallCH, 
-    { ...getCardOpts({} as any), count: donActiveList.length }
+    { ...getCardOpts({} as VirtualZoneCard), count: donActiveList.length }
   );
   donActive.x = getX(coords.getDonActiveX(W)); donActive.y = r3Y;
   const topActiveDon = donActiveList.length > 0 ? donActiveList[donActiveList.length - 1] : null;
@@ -188,11 +188,11 @@ export const createSandboxBoardSide = (
   side.addChild(donActive);
 
   // レストドン (70%サイズ)
-  const donRestList = (p as any).don_rested || [];
+  const donRestList = p.don_rested || [];
   const donRest = createCardContainer(
-    { uuid: `donrest-${p.player_id}`, name: 'Don!! Rest', is_rest: true, card_id: 'DON' } as any, 
+    { uuid: `donrest-${p.player_id}`, name: 'Don!! Rest', is_rest: true, card_id: 'DON' } as VirtualZoneCard, 
     smallCW, smallCH, 
-    { ...getCardOpts({} as any), count: donRestList.length }
+    { ...getCardOpts({} as VirtualZoneCard), count: donRestList.length }
   );
   donRest.x = getX(coords.getDonRestX(W)); donRest.y = r3Y;
   const topRestDon = donRestList.length > 0 ? donRestList[donRestList.length - 1] : null;


### PR DESCRIPTION
## 概要
フロントエンドの **lint を 137 → 0**、ビルド（tsc + vite）緑を維持。挙動不変方針でのクリーンアップ。

## 主な変更
**フル型付け（`any` 94 → 0）**
- 型基盤を新設: `game/types.ts` に `VirtualZoneCard` / `DeckInput` / `DeckCardData` / `BaseCard.attached_to` / `GameState.mulligan_finished`、`api/types.ts` に API レスポンス型
- `localLogic.ts`・`BoardSide`/`SandboxBoardSide`・`CardRenderer`(PIXI)・`RealGame`/`SandboxGame`・`client.ts`/`App.tsx` 等の `any`/`as any` を解消

**React 挙動系**
- `static-components` 31→0: DeckBuilder の内部コンポーネント（SectionTitle/FilterBtn/ColorBtn/StatSection）をモジュールスコープへ外出し（**再レンダリングによる state 喪失バグを是正**）
- `exhaustive-deps`/`set-state-in-effect`: WebSocket・初期化 useEffect は「mount時1回」を維持し、意図を根拠コメント付き eslint-disable で固定

## 検証
- `npm run lint` **0 problems**
- `npm run build`（tsc -b && vite build）**緑**

## 注意
- 型・lint 中心の変更で**挙動は不変方針**ですが、DeckBuilder のフィルタUIや Sandbox/RealGame の描画・WebSocket は**ブラウザでの動作確認推奨**（headless 検証外）。

⚠️ レビュー用。マージはしないでください。

https://claude.ai/code/session_01DwioG4GaLJdQ9wm6FPDPTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwioG4GaLJdQ9wm6FPDPTA)_