### PR TITLE
UI: 効果適用の視覚フィードバック（EffectToast）

### DIFF
--- a/src/screens/RealGame.tsx
+++ b/src/screens/RealGame.tsx
@@ -8,6 +8,7 @@ import { CardDetailSheet } from '../ui/CardDetailSheet';
 import { CardSelectModal } from '../ui/CardSelectModal';
 import { DeckSelectModal, type DeckOption } from '../ui/DeckSelectModal';
 import { ActionLog } from '../ui/ActionLog';
+import { EffectToast, type EffectToastItem } from '../ui/EffectToast';
 import { API_CONFIG } from '../api/api.config';
 import { getCardImageUrl } from '../utils/imageAssets';
 import CONST from '../../shared_constants.json';
@@ -19,6 +20,31 @@ const MOCK_DECKS: DeckOption[] = [
   { id: 'imu.json',  name: 'イム',  leaderId: 'ST01-001' },
   { id: 'nami.json', name: 'ナミ', leaderId: 'OP03-040' },
 ];
+
+// 効果トースト（一時的な視覚フィードバック）対象アクションと表示ラベル。
+// 盤面が動く主要効果のみを対象にし、no-op 系（RULE_PROCESSING 等）は出さない。
+const TOAST_ACTION_LABELS: Record<string, string> = {
+  KO: 'KO',
+  DRAW: 'ドロー',
+  DISCARD: '手札を捨てる',
+  TRASH: 'トラッシュ',
+  BOUNCE: '手札に戻す',
+  MOVE_TO_HAND: '手札に加える',
+  DECK_BOTTOM: 'デッキの下へ',
+  HEAL: 'ライフ回復',
+  PLAY_CARD: '登場',
+  REST: 'レスト',
+};
+// 除去・喪失系は強調表示（赤）にする。
+const TOAST_EMPHASIS_ACTIONS = new Set(['KO', 'TRASH', 'DISCARD', 'BOUNCE', 'MOVE_TO_HAND', 'DECK_BOTTOM']);
+const TOAST_DURATION_MS = 1800;
+
+function effectToastText(ev: ActionEvent): string {
+  const label = TOAST_ACTION_LABELS[ev.action ?? ''] ?? ev.action ?? '';
+  const card = ev.card_name ? `${ev.card_name}: ` : '';
+  const tgt = ev.targets?.length ? ` → ${ev.targets.join(' / ')}` : '';
+  return `${card}${label}${tgt}`;
+}
 
 const PENDING_ACTION_LABELS: Record<string, string> = {
   SELECT_BLOCKER: 'ブロッカー選択',
@@ -67,6 +93,8 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
   const [selectingDeckFor, setSelectingDeckFor] = useState<'p1' | 'p2' | null>(null);
   const [eventLog, setEventLog] = useState<ActionEvent[]>([]);
   const [showLog, setShowLog] = useState(false);
+  const [effectToasts, setEffectToasts] = useState<EffectToastItem[]>([]);
+  const toastIdRef = useRef(0);
 
   const { COLORS } = LAYOUT_CONSTANTS;
   const { Z_INDEX, ALPHA } = LAYOUT_PARAMS;
@@ -76,6 +104,24 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
   const MAX_LOG = 50;
   const addEventLog = useCallback((newEvents: ActionEvent[]) => {
     setEventLog(prev => [...newEvents, ...prev].slice(0, MAX_LOG));
+
+    // 主要効果は一時トーストで視覚フィードバックする（失敗/対象なし/no-op は除外）。
+    const fresh = newEvents.filter(
+      e => e.success !== false && e.action != null && TOAST_ACTION_LABELS[e.action] != null,
+    );
+    if (fresh.length === 0) return;
+    const items: EffectToastItem[] = fresh.slice(0, 4).map(e => ({
+      id: (toastIdRef.current += 1),
+      text: effectToastText(e),
+      emphasis: TOAST_EMPHASIS_ACTIONS.has(e.action ?? ''),
+    }));
+    setEffectToasts(prev => [...prev, ...items].slice(-6));
+    items.forEach(it => {
+      window.setTimeout(
+        () => setEffectToasts(prev => prev.filter(t => t.id !== it.id)),
+        TOAST_DURATION_MS,
+      );
+    });
   }, []);
 
   const { startGame, sendAction, sendBattleAction, isPending, errorToast, setErrorToast } = useGameAction(
@@ -629,6 +675,9 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
           onClose={() => setShowLog(false)}
         />
       )}
+
+      {/* 効果適用の一時的な視覚フィードバック（KO/ドロー/バウンス等） */}
+      <EffectToast toasts={effectToasts} />
 
       {pendingRequest?.action === 'MULLIGAN' && (
         <div style={{

--- a/src/ui/EffectToast.tsx
+++ b/src/ui/EffectToast.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+/**
+ * 効果適用の一時的な視覚フィードバック（トースト）。
+ *
+ * バックエンドの `action_events`（KO/ドロー/バウンス等）を受けて、画面上部中央に
+ * 短時間フェードするバッジを表示する。Pixi キャンバスやゲーム状態には一切干渉しない
+ * 純粋な追加レイヤー（pointerEvents: none）で、表示と自動消滅は親(RealGame)が管理する。
+ *
+ * 注: カードが実際に飛ぶ等の座標アニメーションは視覚QAが必要な将来課題（doc §7-G）。
+ * 本コンポーネントは最小限の「効果が起きたこと」のフィードバックを担う。
+ */
+export interface EffectToastItem {
+  id: number;
+  text: string;
+  emphasis: boolean;
+}
+
+const KEYFRAMES =
+  '@keyframes opcgToastRise{0%{opacity:0;transform:translateY(10px) scale(0.94);}' +
+  '12%{opacity:1;transform:translateY(0) scale(1);}78%{opacity:1;transform:translateY(0) scale(1);}' +
+  '100%{opacity:0;transform:translateY(-12px) scale(1);}}';
+
+export const EffectToast: React.FC<{ toasts: ReadonlyArray<EffectToastItem> }> = ({ toasts }) => {
+  if (toasts.length === 0) return null;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '11%',
+        left: 0,
+        right: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '6px',
+        pointerEvents: 'none',
+        zIndex: 160,
+      }}
+    >
+      <style>{KEYFRAMES}</style>
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          style={{
+            padding: '6px 16px',
+            background: t.emphasis ? 'rgba(155,24,24,0.92)' : 'rgba(22,24,34,0.9)',
+            color: '#fff',
+            borderRadius: '16px',
+            fontSize: '13px',
+            fontWeight: 'bold',
+            fontFamily: 'sans-serif',
+            letterSpacing: '0.5px',
+            boxShadow: '0 3px 14px rgba(0,0,0,0.55)',
+            animation: 'opcgToastRise 1.8s ease-out forwards',
+          }}
+        >
+          {t.text}
+        </div>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## 概要

引き継ぎ資料 §7-G（効果適用の視覚フィードバック）の最小版を実装。

## 変更

- `src/ui/EffectToast.tsx`（新規）: `action_events` を消費し、KO/ドロー/バウンス/トラッシュ/登場等の主要効果を画面上部中央に短時間フェード表示する。純粋な追加レイヤー（`pointerEvents:none`、Pixi/ゲーム状態に非干渉）。
- `src/screens/RealGame.tsx`: `addEventLog` から主要アクションのみ抽出（失敗/対象なし/no-op は除外、除去・喪失系は赤強調）、自己消滅タイマーで管理（id は ref、setState は関数形）。`<EffectToast>` を描画。

## 検証

- `npm run lint` 0 / `npm run build`（tsc+vite）緑

## 注

カードが飛ぶ等の座標アニメーション本体、およびトーストの見栄え・表示時間・位置の最終調整はブラウザでの視覚QAが必要（座標アニメは将来課題）。

https://claude.ai/code/session_01HDbZBri9adNyzRqhD4BKk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDbZBri9adNyzRqhD4BKk9)_