### PR TITLE
feat: RealGame UI 改善(ライフ重ね表示・ステージバグ修正・ミニメニュー・ドラッグ並び替え)

### DIFF
--- a/src/game/cardActions.ts
+++ b/src/game/cardActions.ts
@@ -1,0 +1,56 @@
+import type { CardInstance } from './types';
+import { normalizeCardType } from './cardTypes';
+
+// カードに対して実行可能なアクションの記述子。
+// CardDetailSheet（詳細シート）と CardActionMenu（ミニメニュー）で共有し、
+// 「どのカードでどのボタンを出すか」のロジックを一元化する。
+export type CardActionKey = 'play' | 'attack' | 'don' | 'activate';
+
+export interface CardActionDescriptor {
+  key: CardActionKey;
+  label: string;
+}
+
+const hasActivateMain = (card: CardInstance): boolean =>
+  'text' in card && typeof card.text === 'string' && card.text.includes('起動メイン');
+
+// location: RealGame.getPhysicalLocation 由来の物理ロケーション
+//   ('hand' | 'field' | 'leader' | 'life' | 'trash' | 'deck' | ... )
+// isMyTurn: そのカードが手番プレイヤーの操作可能カードか
+export const getAvailableActions = (
+  card: CardInstance,
+  location: string,
+  isMyTurn: boolean,
+  activeDonCount: number,
+): CardActionDescriptor[] => {
+  if (!isMyTurn) return [];
+
+  const actions: CardActionDescriptor[] = [];
+
+  if (location === 'hand') {
+    actions.push({ key: 'play', label: '登場させる' });
+    return actions;
+  }
+
+  if (location === 'field' || location === 'leader') {
+    const type = normalizeCardType(card.type);
+    const canBattle = type === 'LEADER' || type === 'CHARACTER';
+
+    // 攻撃・ドン付与はリーダー/キャラクターのみ。
+    // ステージ等はここに含めない（従来はロケーションのみで判定し、
+    // ステージにも攻撃/ドン付与が表示されるバグがあった）。
+    if (canBattle) {
+      actions.push({ key: 'attack', label: '攻撃する' });
+      if (activeDonCount > 0) {
+        actions.push({ key: 'don', label: 'ドン!!付与' });
+      }
+    }
+
+    // 起動メイン効果はカード種別を問わず（ステージ含む）テキストで判定。
+    if (hasActivateMain(card)) {
+      actions.push({ key: 'activate', label: '効果起動' });
+    }
+  }
+
+  return actions;
+};

--- a/src/game/cardTypes.ts
+++ b/src/game/cardTypes.ts
@@ -1,0 +1,26 @@
+// カード種別の正規化。バックエンドは英語/日本語の両表記
+// ('STAGE'|'ステージ' 等) を返し得るため、UI 側で一意な型に揃える。
+export type NormalizedCardType = 'LEADER' | 'CHARACTER' | 'EVENT' | 'STAGE' | 'DON' | 'UNKNOWN';
+
+export const normalizeCardType = (t?: string): NormalizedCardType => {
+  switch (t?.toUpperCase()) {
+    case 'LEADER':
+    case 'リーダー':
+      return 'LEADER';
+    case 'CHARACTER':
+    case 'キャラクター':
+      return 'CHARACTER';
+    case 'EVENT':
+    case 'イベント':
+      return 'EVENT';
+    case 'STAGE':
+    case 'ステージ':
+      return 'STAGE';
+    case 'DON':
+    case 'DON!!':
+    case 'ドン!!':
+      return 'DON';
+    default:
+      return 'UNKNOWN';
+  }
+};

--- a/src/layout/layout.config.ts
+++ b/src/layout/layout.config.ts
@@ -120,6 +120,7 @@ export const LAYOUT_PARAMS = {
   Z_INDEX: {
     NOTIFICATION: 100,  // 通知メッセージ、ターン終了ボタン
     OVERLAY: 110,       // 攻撃対象選択オーバーレイ
+    MINI_MENU: 1500,    // カードタップ時のミニアクションメニュー
     SHEET: 2000,        // カード詳細シート (最前面)
   },
 

--- a/src/screens/RealGame.tsx
+++ b/src/screens/RealGame.tsx
@@ -5,7 +5,9 @@ import { calculateCoordinates } from '../layout/layoutEngine';
 import { createBoardSide } from '../ui/BoardSide';
 import { useGameAction } from '../game/actions';
 import { CardDetailSheet } from '../ui/CardDetailSheet';
+import { CardActionMenu } from '../ui/CardActionMenu';
 import { CardSelectModal } from '../ui/CardSelectModal';
+import { getAvailableActions } from '../game/cardActions';
 import { DeckSelectModal, type DeckOption } from '../ui/DeckSelectModal';
 import { ActionLog } from '../ui/ActionLog';
 import { EffectToast, type EffectToastItem } from '../ui/EffectToast';
@@ -79,6 +81,11 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     isMyTurn: boolean;
   } | null>(null);
   const [isDetailMode, setIsDetailMode] = useState(false);
+  const [actionMenu, setActionMenu] = useState<{
+    card: CardInstance;
+    location: string;
+    anchor: { x: number; y: number };
+  } | null>(null);
   const [pendingRequest, setPendingRequest] = useState<PendingRequest | null>(null);
   const [isAttackTargeting, setIsAttackTargeting] = useState(false);
   const [attackingCardUuid, setAttackingCardUuid] = useState<string | null>(null);
@@ -208,6 +215,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
       setAttackingCardUuid(payload.uuid || null);
       setIsAttackTargeting(true);
       setIsDetailMode(false);
+      setActionMenu(null);
       return;
     }
 
@@ -303,7 +311,7 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     ? `🛡 ${pendingRequest!.player_id?.toUpperCase()} の防御選択 — `
     : '';
 
-  const onCardClick = async (card: CardInstance) => {
+  const onCardClick = async (card: CardInstance, pos: { x: number; y: number }) => {
     if (isPending || !gameState) return;
 
     if (isAttackTargeting && attackingCardUuid) {
@@ -390,12 +398,20 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
       payload: { uuid: card.uuid, activePlayerId, currentLoc }
     });
 
-    setSelectedCard({ 
-      card, 
-      location: currentLoc, 
-      isMyTurn: isOperatable 
-    }); 
-    setIsDetailMode(true); 
+    // 操作可能カードで実行可能アクションが1つ以上あれば、詳細シートではなく
+    // カード近傍のミニメニューを開く（タップ→即操作の導線）。
+    const donCount = activePlayerId ? gameState.players[activePlayerId].don_active.length : 0;
+    if (isOperatable && getAvailableActions(card, currentLoc, true, donCount).length > 0) {
+      setActionMenu({ card, location: currentLoc, anchor: pos });
+      return;
+    }
+
+    setSelectedCard({
+      card,
+      location: currentLoc,
+      isMyTurn: isOperatable
+    });
+    setIsDetailMode(true);
   };
   
   useEffect(() => {
@@ -408,6 +424,12 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- request_id 変化時のみ実行する意図（pendingRequest/isAttackTargeting は最新値を本体で参照）
   }, [pendingRequest?.request_id]);
+
+  // 盤面(PIXI)は gameState 変化のたびに全再構築されカード位置が変わり得るため、
+  // 状態変化・新しい選択要求が来たらミニメニューを閉じてアンカーのズレを防ぐ。
+  useEffect(() => {
+    setActionMenu(null);
+  }, [gameState, pendingRequest?.request_id]);
 
   useEffect(() => {
     if (!pixiContainerRef.current || !isSetupComplete) return;
@@ -955,6 +977,22 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
           {isPending ? '送信中...' : 'ターン終了'}
         </button>
       )}
+
+    {actionMenu && (
+      <CardActionMenu
+        card={actionMenu.card}
+        location={actionMenu.location}
+        activeDonCount={activeDonCount}
+        anchor={actionMenu.anchor}
+        onAction={handleAction}
+        onShowDetail={() => {
+          setSelectedCard({ card: actionMenu.card, location: actionMenu.location, isMyTurn: true });
+          setIsDetailMode(true);
+          setActionMenu(null);
+        }}
+        onClose={() => setActionMenu(null)}
+      />
+    )}
 
     {isDetailMode && selectedCard && (
       <CardDetailSheet

--- a/src/ui/BoardSide.tsx
+++ b/src/ui/BoardSide.tsx
@@ -11,7 +11,7 @@ export const createBoardSide = (
   isOpponent: boolean,
   W: number,
   coords: LayoutCoords,
-  onCardClick: (card: CardInstance) => void,
+  onCardClick: (card: CardInstance, pos: { x: number; y: number }) => void,
   selectableUuids?: Set<string>,
   selectedUuids?: Set<string>,
 ) => {
@@ -37,7 +37,7 @@ export const createBoardSide = (
   };
 
   const getCardOpts = (c: VirtualZoneCard) => ({
-    onClick: () => onCardClick(c as CardInstance),
+    onClick: (pos: { x: number; y: number }) => onCardClick(c as CardInstance, pos),
     isOpponent: isOpponent,
     isSelectable: selectableUuids?.has(c.uuid || '') ?? false,
     isSelected: selectedUuids?.has(c.uuid || '') ?? false,

--- a/src/ui/BoardSide.tsx
+++ b/src/ui/BoardSide.tsx
@@ -2,6 +2,7 @@ import * as PIXI from 'pixi.js';
 import type { LayoutCoords } from '../layout/layoutEngine';
 import { createCardContainer } from './CardRenderer';
 import type { PlayerState, CardInstance, BoardCard, VirtualZoneCard } from '../game/types';
+import { normalizeCardType } from '../game/cardTypes';
 import { logger } from '../utils/logger';
 // 未使用のインポートを削除しました
 
@@ -57,10 +58,7 @@ export const createBoardSide = (
   const fieldCards = [...(z.field || [])]; 
 
   if (!stageCard) {
-    const sIdx = fieldCards.findIndex(c => {
-        const t = c.type?.toUpperCase();
-        return t === 'STAGE' || t === 'ステージ';
-    });
+    const sIdx = fieldCards.findIndex(c => normalizeCardType(c.type) === 'STAGE');
 
     if (sIdx >= 0) {
       stageCard = fieldCards[sIdx];
@@ -96,16 +94,68 @@ export const createBoardSide = (
     side.addChild(stg);
   }
 
-  // ライフ (getX適用)
-  const lifeCount = z.life?.length || 0;
-  const life = createCardContainer(
-    { uuid: `life-${p.player_id}`, name: 'Life' } as VirtualZoneCard, 
-    coords.CW, 
-    coords.CH, 
-    { ...getCardOpts({ uuid: `life-${p.player_id}`, name: 'Life' } as VirtualZoneCard), count: lifeCount }
-  );
-  life.x = getX(coords.getLifeX(W)); life.y = r2Y;
-  side.addChild(life);
+  // ライフ: 横向き(90°回転)のカードを少しずつ縦にずらして重ね、
+  // 各カードの表/裏が判別できるように描画する（自分・相手の両側に適用）。
+  const lifeCards = z.life || [];
+  const lifeX = getX(coords.getLifeX(W));
+
+  if (lifeCards.length === 0) {
+    // 0枚は従来どおり EMPTY プレースホルダー（count:0 経路）を表示。
+    const emptyLife = { uuid: `life-${p.player_id}`, name: 'Life' } as VirtualZoneCard;
+    const life = createCardContainer(emptyLife, coords.CW, coords.CH, {
+      ...getCardOpts(emptyLife),
+      count: 0,
+    });
+    life.x = lifeX; life.y = r2Y;
+    side.addChild(life);
+  } else {
+    const lifeScale = 0.85;                 // 6枚程度まで帯に収まるよう少し縮小
+    const lcw = coords.CW * lifeScale;
+    const lch = coords.CH * lifeScale;
+    const n = lifeCards.length;
+    // 横向きカードの縦方向の見かけ高さは lcw。重ね段差は枚数に応じて自動調整し、
+    // スタック全体がカード1枚分(coords.CH)の帯に収まるようにする。
+    const step = n > 1 ? Math.min(lcw * 0.5, (coords.CH - lcw) / (n - 1)) : 0;
+    const stackH = lcw + step * (n - 1);
+
+    // life[0] が山の一番上(ダメージで最初に取られる)。最前面かつ最上段に
+    // 描画するため、z順が後勝ちになるよう逆順で addChild する。
+    for (let i = n - 1; i >= 0; i--) {
+      const c = lifeCards[i];
+      const isFaceUp = c.is_face_up === true;
+      // is_rest 経路の90°回転を流用して横向き描画。onClick には元カード c を渡す。
+      const renderCard = { ...c, is_rest: true } as CardInstance;
+      const lifeCard = createCardContainer(renderCard, lcw, lch, getCardOpts(c));
+      lifeCard.x = lifeX;
+      lifeCard.y = r2Y - stackH / 2 + lcw / 2 + i * step;
+      if (!isFaceUp) {
+        // 裏向きライフは内容を確認できないためタップ無効。
+        lifeCard.eventMode = 'none';
+        lifeCard.cursor = 'default';
+      }
+      side.addChild(lifeCard);
+    }
+
+    // ライフ枚数バッジ(重なりで枚数が読み取りづらい場合の補助)。
+    // 盤面端側(中央のリーダーと逆方向)に小さく表示する。
+    const badgeR = lcw * 0.26;
+    const edgeSign = isOpponent ? 1 : -1; // 自陣ライフは左寄せ→左端、相手は右寄せ→右端
+    const badgeX = lifeX + edgeSign * (lch / 2 + badgeR + 3);
+    const badge = new PIXI.Graphics()
+      .beginFill(0x000000, 0.85)
+      .lineStyle(1, 0xffffff)
+      .drawCircle(badgeX, r2Y, badgeR)
+      .endFill();
+    side.addChild(badge);
+    const badgeText = new PIXI.Text(`${n}`, {
+      fontSize: badgeR * 1.2,
+      fill: 0xffffff,
+      fontWeight: 'bold',
+    });
+    badgeText.anchor.set(0.5);
+    badgeText.position.set(badgeX, r2Y);
+    side.addChild(badgeText);
+  }
 
   // デッキ (getX適用)
   const deck = createCardContainer(

--- a/src/ui/CardActionMenu.tsx
+++ b/src/ui/CardActionMenu.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react';
+import CONST from '../../shared_constants.json';
+import { LAYOUT_CONSTANTS, LAYOUT_PARAMS } from '../layout/layout.config';
+import { getAvailableActions, type CardActionKey } from '../game/cardActions';
+import type { CardInstance } from '../game/types';
+
+interface CardActionMenuProps {
+  card: CardInstance;
+  location: string;
+  activeDonCount: number;
+  anchor: { x: number; y: number }; // タップ位置（CSSピクセル）
+  onAction: (type: string, payload: Record<string, unknown>) => Promise<void>;
+  onShowDetail: () => void;
+  onClose: () => void;
+}
+
+const PANEL_WIDTH = 170;
+
+// カードタップ時にカード近傍へ表示するコンパクトな操作メニュー。
+// 詳細シートを毎回開かずに、攻撃/ドン付与/効果起動/登場を即実行できる。
+export const CardActionMenu: React.FC<CardActionMenuProps> = ({
+  card, location, activeDonCount, anchor, onAction, onShowDetail, onClose,
+}) => {
+  const { COLORS } = LAYOUT_CONSTANTS;
+  const { Z_INDEX, SHAPE } = LAYOUT_PARAMS;
+  const ACTIONS = CONST.c_to_s_interface.GAME_ACTIONS.TYPES;
+
+  // ドン付与は枚数選択のためパネル内をステッパー表示に切り替える。
+  const [donMode, setDonMode] = useState(false);
+  const [donAmount, setDonAmount] = useState(1);
+
+  const actions = getAvailableActions(card, location, true, activeDonCount);
+
+  const handleActionTap = async (key: CardActionKey) => {
+    if (key === 'don') {
+      setDonAmount(1);
+      setDonMode(true);
+      return;
+    }
+    if (key === 'play') {
+      await onAction(ACTIONS.PLAY, { uuid: card.uuid });
+    } else if (key === 'attack') {
+      await onAction(ACTIONS.ATTACK, { uuid: card.uuid });
+    } else if (key === 'activate') {
+      await onAction(ACTIONS.ACTIVATE_MAIN, { uuid: card.uuid });
+    }
+    onClose();
+  };
+
+  const handleAttachDon = async () => {
+    for (let i = 0; i < donAmount; i++) {
+      await onAction(ACTIONS.ATTACH_DON, { uuid: card.uuid });
+    }
+    onClose();
+  };
+
+  // 画面端で見切れないように配置をクランプ。タップ位置が上半分なら下に、
+  // 下半分なら上に開く（カード自体を隠さないため）。
+  const left = Math.min(
+    Math.max(anchor.x - PANEL_WIDTH / 2, 8),
+    window.innerWidth - PANEL_WIDTH - 8,
+  );
+  const openBelow = anchor.y < window.innerHeight / 2;
+  const verticalStyle: React.CSSProperties = openBelow
+    ? { top: Math.min(anchor.y + 16, window.innerHeight - 8) }
+    : { bottom: Math.min(window.innerHeight - anchor.y + 16, window.innerHeight - 8) };
+
+  const panelStyle: React.CSSProperties = {
+    position: 'fixed',
+    left,
+    ...verticalStyle,
+    width: PANEL_WIDTH,
+    background: 'rgba(28, 32, 40, 0.97)',
+    border: '1px solid #4a5360',
+    borderRadius: '10px',
+    boxShadow: '0 6px 20px rgba(0,0,0,0.5)',
+    padding: '8px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    zIndex: Z_INDEX.MINI_MENU,
+    boxSizing: 'border-box',
+  };
+
+  const btnStyle = (bg: string, color: string = '#fff'): React.CSSProperties => ({
+    padding: '11px 10px',
+    borderRadius: SHAPE.CORNER_RADIUS_BTN,
+    border: 'none',
+    background: bg,
+    color,
+    fontWeight: 'bold',
+    fontSize: '0.95rem',
+    cursor: 'pointer',
+    width: '100%',
+  });
+
+  const actionBg: Record<CardActionKey, string> = {
+    play: COLORS.BTN_SUCCESS,
+    attack: COLORS.BTN_DANGER,
+    don: COLORS.BTN_WARNING,
+    activate: COLORS.BTN_PRIMARY,
+  };
+  const actionFg: Record<CardActionKey, string> = {
+    play: '#fff', attack: '#fff', don: '#222', activate: '#fff',
+  };
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, zIndex: Z_INDEX.MINI_MENU }}
+      onPointerDown={onClose}
+    >
+      <div style={panelStyle} onPointerDown={(e) => e.stopPropagation()}>
+        {donMode ? (
+          <>
+            <div style={{ color: '#fff', fontSize: '0.8rem', textAlign: 'center', fontWeight: 'bold' }}>
+              ドン!!付与
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '14px' }}>
+              <button
+                onClick={() => setDonAmount(Math.max(1, donAmount - 1))}
+                style={{ ...btnStyle(COLORS.BTN_SECONDARY), width: '40px', padding: '8px 0' }}
+              >−</button>
+              <div style={{ color: '#fff', fontSize: '1.4rem', fontWeight: 'bold', minWidth: '24px', textAlign: 'center' }}>
+                {donAmount}
+              </div>
+              <button
+                onClick={() => setDonAmount(Math.min(activeDonCount, donAmount + 1))}
+                disabled={donAmount >= activeDonCount}
+                style={{ ...btnStyle(donAmount >= activeDonCount ? COLORS.BTN_DISABLED : COLORS.BTN_SECONDARY), width: '40px', padding: '8px 0' }}
+              >＋</button>
+            </div>
+            <div style={{ color: '#aaa', fontSize: '0.7rem', textAlign: 'center' }}>可能: {activeDonCount}枚</div>
+            <button onClick={handleAttachDon} style={btnStyle(COLORS.BTN_WARNING, '#222')}>付与する</button>
+            <button onClick={() => setDonMode(false)} style={btnStyle(COLORS.BTN_SECONDARY)}>戻る</button>
+          </>
+        ) : (
+          <>
+            {actions.map(a => (
+              <button key={a.key} onClick={() => handleActionTap(a.key)} style={btnStyle(actionBg[a.key], actionFg[a.key])}>
+                {a.label}
+              </button>
+            ))}
+            <button onClick={onShowDetail} style={btnStyle('#5a6573')}>詳細</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/CardDetailSheet.tsx
+++ b/src/ui/CardDetailSheet.tsx
@@ -5,6 +5,7 @@ import { LAYOUT_CONSTANTS, LAYOUT_PARAMS } from '../layout/layout.config';
 // ▼ 変更: imageAssetsから関数をインポート
 import { getCardImageUrl } from '../utils/imageAssets';
 import type { CardInstance, BoardCard, LeaderCard } from '../game/types';
+import { getAvailableActions, type CardActionKey } from '../game/cardActions';
 
 interface CardDetailSheetProps {
   card: CardInstance & { cards?: CardInstance[] };
@@ -79,38 +80,26 @@ export const CardDetailSheet: React.FC<CardDetailSheetProps> = ({ card, location
       );
     }
 
-    const btns: React.ReactElement[] = [];
-    if (isMyTurn && location === 'hand') {
-      btns.push(
-        <button key="play" onClick={() => handleExecute(ACTIONS.PLAY)} style={btnStyle(COLORS.BTN_SUCCESS, COLORS.TEXT_LIGHT)}>
-          登場させる
-        </button>
-      );
-    }
-    if (isMyTurn && (location === 'field' || location === 'leader')) {
-      btns.push(
-        <button key="attack" onClick={() => handleExecute(ACTIONS.ATTACK)} style={btnStyle(COLORS.BTN_DANGER, COLORS.TEXT_LIGHT)}>
-          攻撃する
-        </button>
-      );
-      
-      if (activeDonCount > 0) {
-        btns.push(
-          <button key="don" onClick={() => { setDonAmount(1); setDonMode(true); }} style={btnStyle(COLORS.BTN_WARNING, COLORS.TEXT_DEFAULT)}>
-            ドン!!付与
-          </button>
-        );
-      }
+    // ボタンの表示可否はカード種別・ロケーションに基づき getAvailableActions に一元化。
+    // ステージカードに攻撃/ドン付与が出るバグはこのヘルパー側で防いでいる。
+    const actionStyles: Record<CardActionKey, React.CSSProperties> = {
+      play: btnStyle(COLORS.BTN_SUCCESS, COLORS.TEXT_LIGHT),
+      attack: btnStyle(COLORS.BTN_DANGER, COLORS.TEXT_LIGHT),
+      don: btnStyle(COLORS.BTN_WARNING, COLORS.TEXT_DEFAULT),
+      activate: btnStyle(COLORS.BTN_PRIMARY, COLORS.TEXT_LIGHT),
+    };
+    const actionHandlers: Record<CardActionKey, () => void> = {
+      play: () => handleExecute(ACTIONS.PLAY),
+      attack: () => handleExecute(ACTIONS.ATTACK),
+      don: () => { setDonAmount(1); setDonMode(true); },
+      activate: () => handleExecute(ACTIONS.ACTIVATE_MAIN),
+    };
 
-      if ('text' in card && card.text?.includes('起動メイン')) {
-        btns.push(
-          <button key="activate" onClick={() => handleExecute(ACTIONS.ACTIVATE_MAIN)} style={btnStyle(COLORS.BTN_PRIMARY, COLORS.TEXT_LIGHT)}>
-            効果起動
-          </button>
-        );
-      }
-    }
-    return btns;
+    return getAvailableActions(card, location, isMyTurn, activeDonCount).map(a => (
+      <button key={a.key} onClick={actionHandlers[a.key]} style={actionStyles[a.key]}>
+        {a.label}
+      </button>
+    ));
   };
 
   const overlayStyle: React.CSSProperties = {

--- a/src/ui/CardRenderer.tsx
+++ b/src/ui/CardRenderer.tsx
@@ -24,7 +24,7 @@ export const createCardContainer = (
   card: VirtualZoneCard,
   cw: number,
   ch: number,
-  options: { count?: number; onClick: () => void; isOpponent?: boolean; isSelectable?: boolean; isSelected?: boolean }
+  options: { count?: number; onClick: (pos: { x: number; y: number }) => void; isOpponent?: boolean; isSelectable?: boolean; isSelected?: boolean }
 ) => {
   const container = new PIXI.Container();
   if (card?.uuid) {
@@ -353,7 +353,9 @@ export const createCardContainer = (
         msg: `Card tapped: ${card?.name || 'unknown'}`,
         payload: { uuid: card?.uuid, isOpponent }
       });
-      if (options.onClick) options.onClick();
+      // autoDensity + 全画面キャンバスのため e.global は CSS ピクセル座標と一致。
+      // DOM オーバーレイ(ミニメニュー)の配置にそのまま渡せる。
+      if (options.onClick) options.onClick({ x: e.global.x, y: e.global.y });
     }
   });
 

--- a/src/ui/CardSelectModal.tsx
+++ b/src/ui/CardSelectModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { LAYOUT_CONSTANTS, LAYOUT_PARAMS } from '../layout/layout.config';
 import type { CardInstance } from '../game/types';
 // ▼ 変更: imageAssetsから関数をインポート
@@ -55,17 +55,59 @@ export const CardSelectModal: React.FC<CardSelectModalProps> = ({
     });
   };
 
-  // 並び替え: 配置順を入れ替える（↑↓）。
-  const moveOrder = (uuid: string, dir: -1 | 1) => {
-    setSelected(prev => {
-      const i = prev.indexOf(uuid);
-      const j = i + dir;
-      if (i < 0 || j < 0 || j >= prev.length) return prev;
-      const next = [...prev];
-      [next[i], next[j]] = [next[j], next[i]];
-      return next;
-    });
+  // --- 並び替えモード: ドラッグ&ドロップで配置順を入れ替える ---
+  // 旧来の小さな↑↓ボタンは操作性が悪かったため、Pointer Events による
+  // ドラッグに置き換える（追加ライブラリなし・タッチ対応）。
+  const [dragUuid, setDragUuid] = useState<string | null>(null);
+  const itemRefs = useRef(new Map<string, HTMLDivElement>());
+  const dragMovedRef = useRef(false);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+
+  const arrayMove = (arr: string[], from: number, to: number): string[] => {
+    const next = [...arr];
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item);
+    return next;
   };
+
+  // ポインタ座標直下のカード(ドラッグ中カードを除く)を矩形判定で探す。
+  const findItemAt = (x: number, y: number, exclude: string): string | null => {
+    for (const [uuid, node] of itemRefs.current) {
+      if (uuid === exclude) continue;
+      const r = node.getBoundingClientRect();
+      if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return uuid;
+    }
+    return null;
+  };
+
+  const handleDragPointerDown = (e: React.PointerEvent<HTMLDivElement>, uuid: string) => {
+    if (!isOrderMode) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    dragMovedRef.current = false;
+    dragStartRef.current = { x: e.clientX, y: e.clientY };
+    setDragUuid(uuid);
+  };
+
+  const handleDragPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isOrderMode || dragUuid === null) return;
+    const dx = e.clientX - dragStartRef.current.x;
+    const dy = e.clientY - dragStartRef.current.y;
+    // 6px 動くまではドラッグ開始とみなさない（誤操作・タップ判定の余地）。
+    if (!dragMovedRef.current && Math.hypot(dx, dy) < 6) return;
+    dragMovedRef.current = true;
+
+    const overUuid = findItemAt(e.clientX, e.clientY, dragUuid);
+    if (overUuid) {
+      setSelected(prev => {
+        const from = prev.indexOf(dragUuid);
+        const to = prev.indexOf(overUuid);
+        if (from < 0 || to < 0 || from === to) return prev;
+        return arrayMove(prev, from, to);
+      });
+    }
+  };
+
+  const endDrag = () => setDragUuid(null);
 
   const isValid = isOrderMode
     ? selected.length === selectableCards.length
@@ -105,7 +147,7 @@ export const CardSelectModal: React.FC<CardSelectModalProps> = ({
           <h3 style={{ margin: '0 0 8px 0' }}>{message}</h3>
           <div style={{ fontSize: '0.9rem', color: '#666' }}>
             {isOrderMode
-              ? `配置順を ↑↓ で並び替えてください（${selected.length}枚を上から順に配置）`
+              ? `配置順をドラッグで並び替えてください（${selected.length}枚を①から順に配置）`
               : `選択中: ${selected.length} / ${effMax}枚 (最小 ${minSelect}枚)`}
           </div>
         </div>
@@ -115,26 +157,41 @@ export const CardSelectModal: React.FC<CardSelectModalProps> = ({
           {(isOrderMode
               ? selected.map(uid => candidates.find(c => c.uuid === uid)!).filter(Boolean)
               : candidates
-          ).map((card, idx) => {
+          ).map((card) => {
             const isSelected = selected.includes(card.uuid);
             const canSelect = isSelectable(card.uuid);
             const imageUrl = getCardImageUrl(card.card_id);
             const orderPos = isOrderMode ? selected.indexOf(card.uuid) : -1;
 
+            const isDragging = isOrderMode && dragUuid === card.uuid;
             return (
               <div
                 key={card.uuid}
+                ref={(node) => {
+                  if (node) itemRefs.current.set(card.uuid, node);
+                  else itemRefs.current.delete(card.uuid);
+                }}
                 onClick={() => handleToggle(card.uuid)}
+                onPointerDown={isOrderMode ? (e) => handleDragPointerDown(e, card.uuid) : undefined}
+                onPointerMove={isOrderMode ? handleDragPointerMove : undefined}
+                onPointerUp={isOrderMode ? endDrag : undefined}
+                onPointerCancel={isOrderMode ? endDrag : undefined}
+                onLostPointerCapture={isOrderMode ? endDrag : undefined}
                 style={{
                   border: isSelected ? `3px solid ${COLORS.BTN_PRIMARY}` : '1px solid #ccc',
                   borderRadius: SHAPE.CORNER_RADIUS_CARD,
-                  cursor: canSelect ? 'pointer' : 'default',
+                  cursor: isOrderMode ? (isDragging ? 'grabbing' : 'grab') : (canSelect ? 'pointer' : 'default'),
                   backgroundColor: '#444',
                   position: 'relative',
                   aspectRatio: '0.714',
                   overflow: 'hidden',
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
                   opacity: canSelect ? 1 : 0.4,
+                  touchAction: isOrderMode ? 'none' : undefined,
+                  transform: isDragging ? 'scale(1.08)' : undefined,
+                  boxShadow: isDragging ? '0 8px 20px rgba(0,0,0,0.45)' : undefined,
+                  zIndex: isDragging ? 100 : undefined,
+                  transition: isDragging ? 'none' : 'transform 120ms ease',
                 }}
               >
                 <img
@@ -166,32 +223,14 @@ export const CardSelectModal: React.FC<CardSelectModalProps> = ({
                 )}
 
                 {isOrderMode && (
-                  <>
-                    <div style={{
-                      position: 'absolute', top: '4px', left: '4px',
-                      backgroundColor: COLORS.BTN_PRIMARY, color: 'white',
-                      borderRadius: '50%', width: '22px', height: '22px',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      fontSize: '12px', fontWeight: 'bold', zIndex: 10, border: '2px solid white'
-                    }}>{orderPos + 1}</div>
-                    <div style={{
-                      position: 'absolute', bottom: '2px', left: 0, right: 0,
-                      display: 'flex', justifyContent: 'center', gap: '4px', zIndex: 10,
-                    }}>
-                      <button
-                        onClick={(e) => { e.stopPropagation(); moveOrder(card.uuid, -1); }}
-                        disabled={idx === 0}
-                        style={{ fontSize: '11px', padding: '0 6px', cursor: idx === 0 ? 'default' : 'pointer',
-                                 opacity: idx === 0 ? 0.4 : 1, border: 'none', borderRadius: '3px' }}
-                      >↑</button>
-                      <button
-                        onClick={(e) => { e.stopPropagation(); moveOrder(card.uuid, 1); }}
-                        disabled={idx === selected.length - 1}
-                        style={{ fontSize: '11px', padding: '0 6px', cursor: idx === selected.length - 1 ? 'default' : 'pointer',
-                                 opacity: idx === selected.length - 1 ? 0.4 : 1, border: 'none', borderRadius: '3px' }}
-                      >↓</button>
-                    </div>
-                  </>
+                  <div style={{
+                    position: 'absolute', top: '4px', left: '4px',
+                    backgroundColor: COLORS.BTN_PRIMARY, color: 'white',
+                    borderRadius: '50%', width: '24px', height: '24px',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: '13px', fontWeight: 'bold', zIndex: 10, border: '2px solid white',
+                    pointerEvents: 'none',
+                  }}>{orderPos + 1}</div>
                 )}
               </div>
             );


### PR DESCRIPTION
## 概要
RealGame(対戦画面)のUIを4点改善。

### 1. ライフの表/裏が分かる重ね表示
枚数バッジ付きの単一カードを廃止し、各ライフカードを90°回転(横向き)で少しずつ縦にずらした重ね表示に変更。表向き(`is_face_up`)はカード面、裏向きはカード裏を表示し、自陣・相手の両側に適用。表向きライフはタップで詳細表示、裏向きはタップ無効。枚数バッジも併記。

### 2. ステージカードの攻撃/ドン付与バグ修正
アクション可否をロケーションのみで判定していたのを、カード種別も見る `getAvailableActions` に集約。攻撃・ドン付与はリーダー/キャラクターのみ、起動メイン効果は種別不問。ステージは効果起動のみ表示。

### 3. ミニアクションメニュー
カードタップで大きな詳細モーダルを開く代わりに、カード近傍にコンパクトなボタン群を即表示。攻撃/ドン付与/効果起動/登場をワンタップで実行でき、ドン付与は枚数ステッパー内蔵。詳細は「詳細」ボタンから従来シートを開く。操作不可カードは従来どおり直接シート。

### 4. 並び替えのドラッグ&ドロップ化
サーチ後の山札戻しで使う小さい↑↓ボタンを廃止し、Pointer Events によるドラッグ並び替えに置換(追加依存なし・タッチ対応)。順番バッジは維持。

## 新規ファイル
- `src/game/cardTypes.ts` — カード種別の英/日表記正規化
- `src/game/cardActions.ts` — 実行可能アクション判定(シート・ミニメニュー共有)
- `src/ui/CardActionMenu.tsx` — ミニアクションメニュー

## 検証
- `npm run build`(TypeScript型チェック)/ `npm run lint` 通過
- 見た目・操作感の目視確認はバックエンド起動 + ブラウザが必要

※ バックエンド側の対応PR: gx5gyqe2-art/opcg-sim-backend#23

https://claude.ai/code/session_01KmTVzyanu3FvukHW6upYkD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmTVzyanu3FvukHW6upYkD)_