### PR TITLE
refactor: remove sample deck (imu/nami) references

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,13 @@ export default function App() {
 
   const [selectedDecks, setSelectedDecks] = useState<{ p1: string; p2: string }>(() => {
     const saved = sessionStorage.getItem('opcg_selected_decks');
-    return saved ? JSON.parse(saved) : { p1: 'imu.json', p2: 'nami.json' };
+    if (saved) {
+      const parsed = JSON.parse(saved) as { p1?: string; p2?: string };
+      // db: 形式以外（旧サンプルデッキ 'imu.json' 等の残骸）は無効化して選択し直させる
+      const sanitize = (id?: string) => (id && id.startsWith('db:') ? id : '');
+      return { p1: sanitize(parsed.p1), p2: sanitize(parsed.p2) };
+    }
+    return { p1: '', p2: '' };
   });
 
   const [sandboxOptions, setSandboxOptions] = useState<SandboxOptions>(() => {

--- a/src/api/api.config.ts
+++ b/src/api/api.config.ts
@@ -15,10 +15,5 @@ export const API_CONFIG = {
     HEALTH: '/health',
     CREATE_GAME: '/api/game/create',
     ACTION: '/api/game/action'
-  },
-
-  DEFAULT_GAME_SETTINGS: {
-    P1_DECK: "imu.json",
-    P2_DECK: "nami.json"
   }
 } as const;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -5,7 +5,7 @@ import CONST from '../../shared_constants.json';
 import { logger } from '../utils/logger';
 import { sessionManager } from '../utils/session';
 
-const { BASE_URL, ENDPOINTS, DEFAULT_GAME_SETTINGS } = API_CONFIG;
+const { BASE_URL, ENDPOINTS } = API_CONFIG;
 
 const fetchWithLog = async (url: string, options: RequestInit = {}) => {
   const sid = sessionManager.getSessionId();
@@ -40,8 +40,8 @@ export const apiClient = {
   },
 
   async createGame(
-    p1Deck: string = DEFAULT_GAME_SETTINGS.P1_DECK,
-    p2Deck: string = DEFAULT_GAME_SETTINGS.P2_DECK
+    p1Deck: string,
+    p2Deck: string
   ): Promise<{ game_id: string; state: GameState; pending_request?: PendingRequest }> {
     const res = await fetchWithLog(`${BASE_URL}${ENDPOINTS.CREATE_GAME}`, {
       method: 'POST',

--- a/src/screens/RealGame.tsx
+++ b/src/screens/RealGame.tsx
@@ -18,11 +18,6 @@ import { logger } from '../utils/logger';
 import type { GameState, CardInstance, PendingRequest } from '../game/types';
 import type { ActionEvent } from '../api/types';
 
-const MOCK_DECKS: DeckOption[] = [
-  { id: 'imu.json',  name: 'イム',  leaderId: 'ST01-001' },
-  { id: 'nami.json', name: 'ナミ', leaderId: 'OP03-040' },
-];
-
 // 効果トースト（一時的な視覚フィードバック）対象アクションと表示ラベル。
 // 盤面が動く主要効果のみを対象にし、no-op 系（RULE_PROCESSING 等）は出さない。
 const TOAST_ACTION_LABELS: Record<string, string> = {
@@ -93,8 +88,8 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
 
   const [layoutCoords, setLayoutCoords] = useState<{ x: number, y: number } | null>(null);
   
-  const [p1DeckId, setP1DeckId] = useState(initialP1 || 'imu.json');
-  const [p2DeckId, setP2DeckId] = useState(initialP2 || 'nami.json');
+  const [p1DeckId, setP1DeckId] = useState(initialP1);
+  const [p2DeckId, setP2DeckId] = useState(initialP2);
   const [isSetupComplete, setIsSetupComplete] = useState(!!(initialP1 && initialP2));
   const [deckOptions, setDeckOptions] = useState<DeckOption[]>([]);
   const [selectingDeckFor, setSelectingDeckFor] = useState<'p1' | 'p2' | null>(null);
@@ -148,13 +143,11 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
         const data = await res.json();
         if (data.success) {
           data.decks.forEach((d: { id: string; name: string; leader_id?: string }) => {
-            const id = d.id.endsWith('.json') ? d.id : `db:${d.id}`;
-            options.push({ id, name: d.name, leaderId: d.leader_id });
+            options.push({ id: `db:${d.id}`, name: d.name, leaderId: d.leader_id });
           });
         }
       } catch(e) {
         console.error(e);
-        MOCK_DECKS.forEach(d => options.push(d));
       }
 
       const uniqueMap = new Map();

--- a/src/screens/SandboxGame.tsx
+++ b/src/screens/SandboxGame.tsx
@@ -16,35 +16,6 @@ import { logger } from '../utils/logger';
 import { handleLocalAction } from '../game/localActionHandler';
 import { getCardImageUrl } from '../utils/imageAssets';
 
-const MOCK_DECKS: Record<string, DeckInput> = {
-  'imu.json': {
-    leader: { name: "イム", card_id: "ST01-001", power: 5000, type: "LEADER", life: 5 },
-    cards: Array.from({ length: 50 }, (_, i) => ({
-      name: `聖地マリージョア兵 ${i + 1}`,
-      card_id: `OP01-${String(i + 1).padStart(3, '0')}`,
-      power: 3000 + (i % 5) * 1000,
-      cost: 1 + (i % 5),
-      counter: 1000,
-      type: "CHARACTER",
-      trigger_text: i % 3 === 0 ? "トリガーあり" : "",
-      effect_text: "登場時: カードを1枚引く。"
-    }))
-  },
-  'nami.json': {
-    leader: { name: "ナミ", card_id: "OP03-040", power: 5000, type: "LEADER", life: 5 },
-    cards: Array.from({ length: 50 }, (_, i) => ({
-      name: `クリマ・タクト ${i + 1}`,
-      card_id: `OP03-${String(i + 1).padStart(3, '0')}`,
-      power: 2000 + (i % 4) * 1000,
-      cost: 1 + (i % 4),
-      counter: 2000,
-      type: "EVENT",
-      trigger_text: i % 2 === 0 ? "トリガー: 手札に加える" : "",
-      effect_text: "メイン: 相手のキャラ1枚をレストにする。"
-    }))
-  }
-};
-
 type DragState = { card: CardInstance; sprite: PIXI.Container; startPos: { x: number, y: number }; } | null;
 
 // 進行中のローカルサンドボックス状態を保存するsessionStorageキー（クラッシュ/リロード復帰用）
@@ -816,13 +787,10 @@ export const SandboxGame = ({
           const pid = myPlayerId === 'both' ? ((params.player_id as string) || 'p1') : myPlayerId;
 
           const getDeckData = async (deckId: string) => {
-              if (!deckId) return { leader: [], cards: [] };
-              if (MOCK_DECKS[deckId]) return MOCK_DECKS[deckId];
-              let cacheKey = `opcg_deck_${deckId}`;
-              if (deckId.startsWith('db:')) cacheKey = `opcg_deck_${deckId.substring(3)}`;
+              if (!deckId || !deckId.startsWith('db:')) return { leader: [], cards: [] };
+              const cacheKey = `opcg_deck_${deckId.substring(3)}`;
               const cached = localStorage.getItem(cacheKey);
               if (cached) { try { return JSON.parse(cached); } catch { /* キャッシュ不正は無視 */ } }
-              if (!deckId.startsWith('db:') && !['imu.json', 'nami.json'].includes(deckId)) return { leader: [], cards: [] };
               const res = await fetch(`${API_CONFIG.BASE_URL}/api/deck/get?id=${deckId}`);
               if (!res.ok) throw new Error();
               const data = await res.json();


### PR DESCRIPTION
サンプルデッキ (imu/nami) を参照する機能をすべて削除し、デッキは Firestore (`db:<id>`) のみで扱う構成にしました。

## 変更内容
- `api.config.ts` の `DEFAULT_GAME_SETTINGS`（imu/nami デフォルト）を削除し、`createGame` を明示的な引数必須に変更
- `RealGame.tsx` / `SandboxGame.tsx` の `MOCK_DECKS` と imu/nami 許可リスト判定を削除
- デッキ一覧・サンドボックスのデッキ取得を Firestore (`db:`) デッキのみ扱うように変更
- `App.tsx` のデッキ初期値を空に変更。sessionStorage に残った旧 `imu.json` 等の値は `db:` 形式でなければ無効化して選び直させるガードを追加

## 検証
- `npm run build`（tsc + vite build）成功
- `grep -rn "imu\|nami" src/` → 残存参照なし（無関係な文字列を除く）

## 削除後の挙動
デッキ未選択でゲームを開始すると RealGame のデッキ選択画面が表示され、選択肢は Firestore に保存されたデッキのみになります。Firestore にデッキが無い場合は、先にデッキビルダーでの作成が必要です。

https://claude.ai/code/session_01Pq5LTp9xmf24qm3hjKhjKk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pq5LTp9xmf24qm3hjKhjKk)_