### PR TITLE
ドン!!返却(SELECT_RESOURCE)の対象選択モーダル対応

### DIFF
--- a/src/screens/RealGame.tsx
+++ b/src/screens/RealGame.tsx
@@ -625,6 +625,8 @@ export const RealGame = ({ p1Deck: initialP1, p2Deck: initialP2, onBack }: { p1D
     !isBoardSelectMode && (
       pendingRequest?.action === CONST.c_to_s_interface.PENDING_ACTION_TYPES.SEARCH_AND_SELECT ||
       pendingRequest?.action === CONST.c_to_s_interface.PENDING_ACTION_TYPES.ARRANGE_DECK ||
+      // ドン!!返却(RETURN_DON)の対象選択。場のドン!!（候補）からモーダルで選ばせる。
+      pendingRequest?.action === CONST.c_to_s_interface.PENDING_ACTION_TYPES.SELECT_RESOURCE ||
       pendingRequest?.action === CONST.c_to_s_interface.BATTLE_ACTIONS.TYPES.SELECT_COUNTER
     );
     


### PR DESCRIPTION
## 概要
バックエンドが RETURN_DON（ドン!!返却）解決時に送る `SELECT_RESOURCE` 要求を、既存のカード選択モーダル（`CardSelectModal`）で処理するようにした。

候補（自分の場のドン!!：アクティブ/レスト/付与中）から戻す枚数を選び、`selected_uuids` を `RESOLVE_EFFECT_SELECTION` で返す。

## 確認
- 型チェック（tsc --noEmit）pass
- 本番ビルド（vite build）成功

※バックエンドの対応は opcg-sim-backend の同名ブランチ。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsyUkHA64VkwzXxm1Fyp3Y)_